### PR TITLE
[BSVR-125/FEAT] 시야 찾기 서버 통신 1차 구현

### DIFF
--- a/app/src/main/java/com/depromeet/spot/di/DataSourceModule.kt
+++ b/app/src/main/java/com/depromeet/spot/di/DataSourceModule.kt
@@ -1,8 +1,10 @@
 package com.depromeet.spot.di
 
 import com.depromeet.data.datasource.ExampleDataSource
+import com.depromeet.data.datasource.ViewfinderDataSource
 import com.depromeet.data.datasource.WebSvgDataSource
 import com.depromeet.data.datasource.remote.ExampleDataSourcelmpl
+import com.depromeet.data.datasource.remote.ViewfinderDataSourceImpl
 import com.depromeet.data.datasource.remote.WebSvgDataSourceImpl
 import dagger.Binds
 import dagger.Module
@@ -25,4 +27,10 @@ abstract class DataSourceModule {
     abstract fun bindWebSvgDataSource(
         webSvgDataSourceImpl: WebSvgDataSourceImpl
     ): WebSvgDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindViewfinderDataSource(
+        viewfinderDataSourceImpl: ViewfinderDataSourceImpl
+    ): ViewfinderDataSource
 }

--- a/app/src/main/java/com/depromeet/spot/di/RepositoryModule.kt
+++ b/app/src/main/java/com/depromeet/spot/di/RepositoryModule.kt
@@ -1,8 +1,10 @@
 package com.depromeet.spot.di
 
 import com.depromeet.data.repository.ExampleRepositoryImpl
+import com.depromeet.data.repository.ViewfinderRepositoryImpl
 import com.depromeet.data.repository.WebSvgRepositoryImpl
 import com.depromeet.domain.repository.ExampleRepository
+import com.depromeet.domain.repository.ViewfinderRepository
 import com.depromeet.domain.repository.WebSvgRepository
 import dagger.Binds
 import dagger.Module
@@ -26,4 +28,10 @@ abstract class RepositoryModule {
     abstract fun bindWebSvgRepository(
         webSvgRepositoryImpl: WebSvgRepositoryImpl
     ): WebSvgRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindViewfinderRepository(
+        viewfinderRepositoryImpl: ViewfinderRepositoryImpl
+    ): ViewfinderRepository
 }

--- a/app/src/main/java/com/depromeet/spot/di/ServiceModule.kt
+++ b/app/src/main/java/com/depromeet/spot/di/ServiceModule.kt
@@ -1,12 +1,14 @@
 package com.depromeet.spot.di
 
 import com.depromeet.data.remote.ExampleService
+import com.depromeet.data.remote.ViewfinderService
 import com.depromeet.data.remote.WebSvgApiService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import retrofit2.create
 import javax.inject.Singleton
 
 @Module
@@ -17,6 +19,11 @@ object ServiceModule {
     @Singleton
     fun provideMockService(retrofit: Retrofit): ExampleService =
         retrofit.create(ExampleService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideViewfinderService(retrofit: Retrofit): ViewfinderService =
+        retrofit.create(ViewfinderService::class.java)
 
     @Provides
     @Singleton

--- a/data/src/main/java/com/depromeet/data/datasource/ViewfinderDataSource.kt
+++ b/data/src/main/java/com/depromeet/data/datasource/ViewfinderDataSource.kt
@@ -1,7 +1,7 @@
 package com.depromeet.data.datasource
 
-import com.depromeet.data.model.response.StadiumResponseDto
-import com.depromeet.data.model.response.StadiumsResponseDto
+import com.depromeet.data.model.response.viewfinder.StadiumResponseDto
+import com.depromeet.data.model.response.viewfinder.StadiumsResponseDto
 
 interface ViewfinderDataSource {
     suspend fun getStadiums(): List<StadiumsResponseDto>

--- a/data/src/main/java/com/depromeet/data/datasource/ViewfinderDataSource.kt
+++ b/data/src/main/java/com/depromeet/data/datasource/ViewfinderDataSource.kt
@@ -1,9 +1,11 @@
 package com.depromeet.data.datasource
 
+import com.depromeet.data.model.response.viewfinder.BlockReviewResponseDto
 import com.depromeet.data.model.response.viewfinder.StadiumResponseDto
 import com.depromeet.data.model.response.viewfinder.StadiumsResponseDto
 
 interface ViewfinderDataSource {
     suspend fun getStadiums(): List<StadiumsResponseDto>
     suspend fun getStadium(id: Int): StadiumResponseDto
+    suspend fun getBlockReviews(stadiumId: Int, blockId: String): BlockReviewResponseDto
 }

--- a/data/src/main/java/com/depromeet/data/datasource/ViewfinderDataSource.kt
+++ b/data/src/main/java/com/depromeet/data/datasource/ViewfinderDataSource.kt
@@ -1,0 +1,9 @@
+package com.depromeet.data.datasource
+
+import com.depromeet.data.model.response.StadiumResponseDto
+import com.depromeet.data.model.response.StadiumsResponseDto
+
+interface ViewfinderDataSource {
+    suspend fun getStadiums(): List<StadiumsResponseDto>
+    suspend fun getStadium(id: Int): StadiumResponseDto
+}

--- a/data/src/main/java/com/depromeet/data/datasource/remote/ViewfinderDataSourceImpl.kt
+++ b/data/src/main/java/com/depromeet/data/datasource/remote/ViewfinderDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.depromeet.data.datasource.remote
 
 import com.depromeet.data.datasource.ViewfinderDataSource
+import com.depromeet.data.model.response.viewfinder.BlockReviewResponseDto
 import com.depromeet.data.model.response.viewfinder.StadiumResponseDto
 import com.depromeet.data.model.response.viewfinder.StadiumsResponseDto
 import com.depromeet.data.remote.ViewfinderService
@@ -15,5 +16,9 @@ class ViewfinderDataSourceImpl @Inject constructor(
 
     override suspend fun getStadium(id: Int): StadiumResponseDto {
         return viewfinderService.getStadium(id)
+    }
+
+    override suspend fun getBlockReviews(stadiumId: Int, blockId: String): BlockReviewResponseDto {
+        return viewfinderService.getBlockReviews(stadiumId, blockId)
     }
 }

--- a/data/src/main/java/com/depromeet/data/datasource/remote/ViewfinderDataSourceImpl.kt
+++ b/data/src/main/java/com/depromeet/data/datasource/remote/ViewfinderDataSourceImpl.kt
@@ -1,0 +1,19 @@
+package com.depromeet.data.datasource.remote
+
+import com.depromeet.data.datasource.ViewfinderDataSource
+import com.depromeet.data.model.response.StadiumResponseDto
+import com.depromeet.data.model.response.StadiumsResponseDto
+import com.depromeet.data.remote.ViewfinderService
+import javax.inject.Inject
+
+class ViewfinderDataSourceImpl @Inject constructor(
+    private val viewfinderService: ViewfinderService
+): ViewfinderDataSource {
+    override suspend fun getStadiums(): List<StadiumsResponseDto> {
+        return viewfinderService.getStadiums()
+    }
+
+    override suspend fun getStadium(id: Int): StadiumResponseDto {
+        return viewfinderService.getStadium(id)
+    }
+}

--- a/data/src/main/java/com/depromeet/data/datasource/remote/ViewfinderDataSourceImpl.kt
+++ b/data/src/main/java/com/depromeet/data/datasource/remote/ViewfinderDataSourceImpl.kt
@@ -1,8 +1,8 @@
 package com.depromeet.data.datasource.remote
 
 import com.depromeet.data.datasource.ViewfinderDataSource
-import com.depromeet.data.model.response.StadiumResponseDto
-import com.depromeet.data.model.response.StadiumsResponseDto
+import com.depromeet.data.model.response.viewfinder.StadiumResponseDto
+import com.depromeet.data.model.response.viewfinder.StadiumsResponseDto
 import com.depromeet.data.remote.ViewfinderService
 import javax.inject.Inject
 

--- a/data/src/main/java/com/depromeet/data/mapper/ViewfinderMapper.kt
+++ b/data/src/main/java/com/depromeet/data/mapper/ViewfinderMapper.kt
@@ -1,7 +1,9 @@
 package com.depromeet.data.mapper
 
+import com.depromeet.data.model.response.viewfinder.BlockReviewResponseDto
 import com.depromeet.data.model.response.viewfinder.StadiumResponseDto
 import com.depromeet.data.model.response.viewfinder.StadiumsResponseDto
+import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
 import com.depromeet.domain.entity.response.viewfinder.StadiumResponse
 import com.depromeet.domain.entity.response.viewfinder.StadiumsResponse
 
@@ -32,3 +34,55 @@ fun StadiumResponseDto.toStadiumResponse() = StadiumResponse(
     thumbnail = thumbnail,
     stadiumUrl = seatChartWithLabel
 )
+
+fun BlockReviewResponseDto.toBlockReviewResponse() = BlockReviewResponse(
+    keywords = keywords.map { it.toKeywordResponse() },
+    reviews = reviews.map { it.toReviewResponse() },
+    totalCount = totalCount,
+    filteredCount = filteredCount,
+    offset = offset,
+    limit = limit,
+    hasMore = hasMore,
+    filter = filter.toReviewFilterResponse()
+)
+
+fun BlockReviewResponseDto.KeywordResponseDto.toKeywordResponse() =
+    BlockReviewResponse.KeywordResponse(
+        content = content,
+        count = count
+    )
+
+fun BlockReviewResponseDto.ReviewResponseDto.toReviewResponse() =
+    BlockReviewResponse.ReviewResponse(
+        id = id,
+        userId = userId,
+        blockId = blockId,
+        seatId = seatId,
+        rowId = rowId,
+        seatNumber = seatNumber,
+        date = date,
+        content = content,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        images = images.map { it.toReviewImageResponse() },
+        keywords = keywords.map { it.toReviewKeywordResponse() }
+    )
+
+fun BlockReviewResponseDto.ReviewFilterResponseDto.toReviewFilterResponse() =
+    BlockReviewResponse.ReviewFilterResponse(
+        rowId = rowId,
+        seatNumber = seatNumber
+    )
+
+fun BlockReviewResponseDto.ReviewResponseDto.ReviewImageResponseDto.toReviewImageResponse() =
+    BlockReviewResponse.ReviewResponse.ReviewImageResponse(
+        id = id,
+        url = url
+    )
+
+fun BlockReviewResponseDto.ReviewResponseDto.ReviewKeywordResponseDto.toReviewKeywordResponse() =
+    BlockReviewResponse.ReviewResponse.ReviewKeywordResponse(
+        id = id,
+        content = content,
+        isPositive = isPositive
+    )

--- a/data/src/main/java/com/depromeet/data/mapper/ViewfinderMapper.kt
+++ b/data/src/main/java/com/depromeet/data/mapper/ViewfinderMapper.kt
@@ -1,0 +1,34 @@
+package com.depromeet.data.mapper
+
+import com.depromeet.data.model.response.StadiumResponseDto
+import com.depromeet.data.model.response.StadiumsResponseDto
+import com.depromeet.domain.entity.response.viewfinder.StadiumResponse
+import com.depromeet.domain.entity.response.viewfinder.StadiumsResponse
+
+fun StadiumsResponseDto.toStadiumsResponse() = StadiumsResponse(
+    id = id,
+    name = name,
+    homeTeams = homeTeams.map { it.toHomeTeamsResponse() },
+    thumbnail = thumbnail,
+    isActive = isActive
+)
+
+fun StadiumsResponseDto.HomeTeamsResponseDto.toHomeTeamsResponse() =
+    StadiumsResponse.HomeTeamsResponse(
+        id = id,
+        alias = alias,
+        color = color.toColorResponse()
+    )
+
+fun StadiumsResponseDto.HomeTeamsResponseDto.ColorResponseDto.toColorResponse() =
+    StadiumsResponse.HomeTeamsResponse.ColorResponse(
+        red = red, green = green, blue = blue
+    )
+
+fun StadiumResponseDto.toStadiumResponse() = StadiumResponse(
+    id = id,
+    name = name,
+    homeTeams = homeTeams.map { it.toHomeTeamsResponse() },
+    thumbnail = thumbnail,
+    stadiumUrl = seatChartWithLabel
+)

--- a/data/src/main/java/com/depromeet/data/mapper/ViewfinderMapper.kt
+++ b/data/src/main/java/com/depromeet/data/mapper/ViewfinderMapper.kt
@@ -1,7 +1,7 @@
 package com.depromeet.data.mapper
 
-import com.depromeet.data.model.response.StadiumResponseDto
-import com.depromeet.data.model.response.StadiumsResponseDto
+import com.depromeet.data.model.response.viewfinder.StadiumResponseDto
+import com.depromeet.data.model.response.viewfinder.StadiumsResponseDto
 import com.depromeet.domain.entity.response.viewfinder.StadiumResponse
 import com.depromeet.domain.entity.response.viewfinder.StadiumsResponse
 

--- a/data/src/main/java/com/depromeet/data/mapper/ViewfinderMapper.kt
+++ b/data/src/main/java/com/depromeet/data/mapper/ViewfinderMapper.kt
@@ -81,8 +81,7 @@ fun BlockReviewResponseDto.ReviewResponseDto.ReviewImageResponseDto.toReviewImag
     )
 
 fun BlockReviewResponseDto.ReviewResponseDto.ReviewKeywordResponseDto.toReviewKeywordResponse() =
-    BlockReviewResponse.ReviewResponse.ReviewKeywordResponse(
-        id = id,
+    BlockReviewResponse.KeywordResponse(
         content = content,
-        isPositive = isPositive
+        isPositive = isPositive,
     )

--- a/data/src/main/java/com/depromeet/data/model/response/StadiumResponseDto.kt
+++ b/data/src/main/java/com/depromeet/data/model/response/StadiumResponseDto.kt
@@ -1,0 +1,18 @@
+package com.depromeet.data.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StadiumResponseDto(
+    @SerialName("id")
+    val id: Int,
+    @SerialName("name")
+    val name: String,
+    @SerialName("homeTeams")
+    val homeTeams: List<StadiumsResponseDto.HomeTeamsResponseDto>,
+    @SerialName("thumbnail")
+    val thumbnail: String,
+    @SerialName("seatChartWithLabel")
+    val seatChartWithLabel: String,
+)

--- a/data/src/main/java/com/depromeet/data/model/response/StadiumsResponseDto.kt
+++ b/data/src/main/java/com/depromeet/data/model/response/StadiumsResponseDto.kt
@@ -1,0 +1,40 @@
+package com.depromeet.data.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StadiumsResponseDto(
+    @SerialName("id")
+    val id: Int,
+    @SerialName("name")
+    val name: String,
+    @SerialName("homeTeams")
+    val homeTeams: List<HomeTeamsResponseDto>,
+    @SerialName("thumbnail")
+    val thumbnail: String,
+    @SerialName("isActive")
+    val isActive: Boolean,
+) {
+    @Serializable
+    data class HomeTeamsResponseDto(
+        @SerialName("id")
+        val id: Int,
+        @SerialName("alias")
+        val alias: String,
+        @SerialName("color")
+        val color: ColorResponseDto,
+    ) {
+        @Serializable
+        data class ColorResponseDto(
+            @SerialName("red")
+            val red: Int,
+            @SerialName("green")
+            val green: Int,
+            @SerialName("blue")
+            val blue: Int,
+        )
+    }
+}
+
+

--- a/data/src/main/java/com/depromeet/data/model/response/viewfinder/BlockReviewResponseDto.kt
+++ b/data/src/main/java/com/depromeet/data/model/response/viewfinder/BlockReviewResponseDto.kt
@@ -1,0 +1,87 @@
+package com.depromeet.data.model.response.viewfinder
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BlockReviewResponseDto(
+    @SerialName("keywords")
+    val keywords: List<KeywordResponseDto>,
+    @SerialName("reviews")
+    val reviews: List<ReviewResponseDto>,
+    @SerialName("totalCount")
+    val totalCount: Int,
+    @SerialName("filteredCount")
+    val filteredCount: Int,
+    @SerialName("offset")
+    val offset: Int,
+    @SerialName("limit")
+    val limit: Int,
+    @SerialName("hasMore")
+    val hasMore: Boolean,
+    @SerialName("filter")
+    val filter: ReviewFilterResponseDto
+) {
+    @Serializable
+    data class KeywordResponseDto(
+        @SerialName("content")
+        val content: String,
+        @SerialName("count")
+        val count: Int
+    )
+
+    @Serializable
+    data class ReviewResponseDto(
+        @SerialName("id")
+        val id: Long,
+        @SerialName("userId")
+        val userId: Long,
+        @SerialName("blockId")
+        val blockId: Int,
+        @SerialName("seatId")
+        val seatId: Int,
+        @SerialName("rowId")
+        val rowId: Int,
+        @SerialName("seatNumber")
+        val seatNumber: Int,
+        @SerialName("date")
+        val date: String,
+        @SerialName("content")
+        val content: String,
+        @SerialName("createdAt")
+        val createdAt: String,
+        @SerialName("updatedAt")
+        val updatedAt: String,
+        @SerialName("images")
+        val images: List<ReviewImageResponseDto>,
+        @SerialName("keywords")
+        val keywords: List<ReviewKeywordResponseDto>,
+
+        ) {
+        @Serializable
+        data class ReviewImageResponseDto(
+            @SerialName("id")
+            val id: Int,
+            @SerialName("url")
+            val url: String,
+        )
+
+        @Serializable
+        data class ReviewKeywordResponseDto(
+            @SerialName("id")
+            val id: Int,
+            @SerialName("content")
+            val content: String,
+            @SerialName("isPositive")
+            val isPositive: Boolean,
+        )
+    }
+
+    @Serializable
+    data class ReviewFilterResponseDto(
+        @SerialName("rowId")
+        val rowId: Int,
+        @SerialName("seatNumber")
+        val seatNumber: Int,
+    )
+}

--- a/data/src/main/java/com/depromeet/data/model/response/viewfinder/StadiumResponseDto.kt
+++ b/data/src/main/java/com/depromeet/data/model/response/viewfinder/StadiumResponseDto.kt
@@ -1,4 +1,4 @@
-package com.depromeet.data.model.response
+package com.depromeet.data.model.response.viewfinder
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/data/src/main/java/com/depromeet/data/model/response/viewfinder/StadiumsResponseDto.kt
+++ b/data/src/main/java/com/depromeet/data/model/response/viewfinder/StadiumsResponseDto.kt
@@ -1,4 +1,4 @@
-package com.depromeet.data.model.response
+package com.depromeet.data.model.response.viewfinder
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/data/src/main/java/com/depromeet/data/remote/ViewfinderService.kt
+++ b/data/src/main/java/com/depromeet/data/remote/ViewfinderService.kt
@@ -1,0 +1,16 @@
+package com.depromeet.data.remote
+
+import com.depromeet.data.model.response.StadiumResponseDto
+import com.depromeet.data.model.response.StadiumsResponseDto
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface ViewfinderService {
+    @GET("/api/v1/stadiums")
+    suspend fun getStadiums(): List<StadiumsResponseDto>
+
+    @GET("/api/v1/stadiums/{stadiumId}")
+    suspend fun getStadium(
+        @Path("stadiumId") stadiumId: Int
+    ): StadiumResponseDto
+}

--- a/data/src/main/java/com/depromeet/data/remote/ViewfinderService.kt
+++ b/data/src/main/java/com/depromeet/data/remote/ViewfinderService.kt
@@ -1,7 +1,8 @@
 package com.depromeet.data.remote
 
-import com.depromeet.data.model.response.StadiumResponseDto
-import com.depromeet.data.model.response.StadiumsResponseDto
+import com.depromeet.data.model.response.viewfinder.BlockReviewResponseDto
+import com.depromeet.data.model.response.viewfinder.StadiumResponseDto
+import com.depromeet.data.model.response.viewfinder.StadiumsResponseDto
 import retrofit2.http.GET
 import retrofit2.http.Path
 
@@ -13,4 +14,10 @@ interface ViewfinderService {
     suspend fun getStadium(
         @Path("stadiumId") stadiumId: Int
     ): StadiumResponseDto
+
+    @GET("/api/v1/stadiums/{stadiumId}/blocks/{blockId}/reviews")
+    suspend fun getBlockReviews(
+        @Path("stadiumId") stadiumId: Int,
+        @Path("blockId") blockId: String
+    ): BlockReviewResponseDto
 }

--- a/data/src/main/java/com/depromeet/data/repository/ViewfinderRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/data/repository/ViewfinderRepositoryImpl.kt
@@ -13,19 +13,15 @@ import javax.inject.Inject
 class ViewfinderRepositoryImpl @Inject constructor(
     private val viewfinderDataSource: ViewfinderDataSource
 ) : ViewfinderRepository {
-    override suspend fun getStadiums(): List<StadiumsResponse> {
-        return try {
+    override suspend fun getStadiums(): Result<List<StadiumsResponse>> {
+        return runCatching {
             viewfinderDataSource.getStadiums().map { it.toStadiumsResponse() }
-        } catch (e: Exception) {
-            emptyList()
         }
     }
 
     override suspend fun getStadium(id: Int): Result<StadiumResponse> {
-        return try {
-            Result.success(viewfinderDataSource.getStadium(id).toStadiumResponse())
-        } catch (e: Exception) {
-            Result.failure(e)
+        return runCatching {
+            viewfinderDataSource.getStadium(id).toStadiumResponse()
         }
     }
 
@@ -33,12 +29,8 @@ class ViewfinderRepositoryImpl @Inject constructor(
         stadiumId: Int,
         blockId: String
     ): Result<BlockReviewResponse> {
-        return try {
-            Result.success(
-                viewfinderDataSource.getBlockReviews(stadiumId, blockId).toBlockReviewResponse()
-            )
-        } catch (e: Exception) {
-            Result.failure(e)
+        return runCatching {
+            viewfinderDataSource.getBlockReviews(stadiumId, blockId).toBlockReviewResponse()
         }
     }
 }

--- a/data/src/main/java/com/depromeet/data/repository/ViewfinderRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/data/repository/ViewfinderRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.depromeet.data.repository
+
+import com.depromeet.data.datasource.ViewfinderDataSource
+import com.depromeet.data.mapper.toStadiumResponse
+import com.depromeet.data.mapper.toStadiumsResponse
+import com.depromeet.domain.entity.response.viewfinder.StadiumResponse
+import com.depromeet.domain.entity.response.viewfinder.StadiumsResponse
+import com.depromeet.domain.repository.ViewfinderRepository
+import javax.inject.Inject
+
+class ViewfinderRepositoryImpl @Inject constructor(
+    private val viewfinderDataSource: ViewfinderDataSource
+) : ViewfinderRepository {
+    override suspend fun getStadiums(): List<StadiumsResponse> {
+        return try {
+            viewfinderDataSource.getStadiums().map { it.toStadiumsResponse() }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getStadium(id: Int): Result<StadiumResponse> {
+        return try {
+            Result.success(viewfinderDataSource.getStadium(id).toStadiumResponse())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/data/src/main/java/com/depromeet/data/repository/ViewfinderRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/data/repository/ViewfinderRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package com.depromeet.data.repository
 
 import com.depromeet.data.datasource.ViewfinderDataSource
+import com.depromeet.data.mapper.toBlockReviewResponse
 import com.depromeet.data.mapper.toStadiumResponse
 import com.depromeet.data.mapper.toStadiumsResponse
+import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
 import com.depromeet.domain.entity.response.viewfinder.StadiumResponse
 import com.depromeet.domain.entity.response.viewfinder.StadiumsResponse
 import com.depromeet.domain.repository.ViewfinderRepository
@@ -22,6 +24,19 @@ class ViewfinderRepositoryImpl @Inject constructor(
     override suspend fun getStadium(id: Int): Result<StadiumResponse> {
         return try {
             Result.success(viewfinderDataSource.getStadium(id).toStadiumResponse())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getBlockReviews(
+        stadiumId: Int,
+        blockId: String
+    ): Result<BlockReviewResponse> {
+        return try {
+            Result.success(
+                viewfinderDataSource.getBlockReviews(stadiumId, blockId).toBlockReviewResponse()
+            )
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/data/src/main/java/com/depromeet/data/repository/WebSvgRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/data/repository/WebSvgRepositoryImpl.kt
@@ -7,10 +7,9 @@ import javax.inject.Inject
 class WebSvgRepositoryImpl @Inject constructor(
     private val webSvgDataSourceImpl: WebSvgDataSourceImpl
 ) : WebSvgRepository {
-    override suspend fun downloadFileWithDynamicUrlAsync(url: String): String = try {
-        val responseBody = webSvgDataSourceImpl.downloadFileWithDynamicUrlAsync(url)
-        responseBody.string()
-    } catch (e: Exception) {
-        e.message.toString()
-    }
+    override suspend fun downloadFileWithDynamicUrlAsync(url: String): Result<String> =
+        runCatching {
+            val responseBody = webSvgDataSourceImpl.downloadFileWithDynamicUrlAsync(url)
+            responseBody.string()
+        }
 }

--- a/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/BlockReviewResponse.kt
+++ b/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/BlockReviewResponse.kt
@@ -21,8 +21,8 @@ data class BlockReviewResponse(
     )
 
     data class ReviewResponse(
-        val id: Long = 0,
-        val userId: Long = 0,
+        val id: Long,
+        val userId: Long,
         val blockId: Int = 0,
         val seatId: Int = 0,
         val rowId: Int = 0,
@@ -35,7 +35,7 @@ data class BlockReviewResponse(
         val keywords: List<KeywordResponse> = emptyList(),
     ) {
         data class ReviewImageResponse(
-            val id: Int = 0,
+            val id: Int,
             val url: String = "",
         )
 

--- a/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/BlockReviewResponse.kt
+++ b/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/BlockReviewResponse.kt
@@ -1,0 +1,50 @@
+package com.depromeet.domain.entity.response.viewfinder
+
+
+data class BlockReviewResponse(
+    val keywords: List<KeywordResponse> = emptyList(),
+    val reviews: List<ReviewResponse> = emptyList(),
+    val totalCount: Int = 0,
+    val filteredCount: Int = 0,
+    val offset: Int = 0,
+    val limit: Int = 0,
+    val hasMore: Boolean = false,
+    val filter: ReviewFilterResponse = ReviewFilterResponse()
+) {
+    data class KeywordResponse(
+        val content: String = "",
+        val count: Int = 0
+    )
+
+    data class ReviewResponse(
+        val id: Long = 0,
+        val userId: Long = 0,
+        val blockId: Int = 0,
+        val seatId: Int = 0,
+        val rowId: Int = 0,
+        val seatNumber: Int = 0,
+        val date: String = "",
+        val content: String = "",
+        val createdAt: String = "",
+        val updatedAt: String = "",
+        val images: List<ReviewImageResponse> = emptyList(),
+        val keywords: List<ReviewKeywordResponse> = emptyList(),
+
+        ) {
+        data class ReviewImageResponse(
+            val id: Int = 0,
+            val url: String = "",
+        )
+
+        data class ReviewKeywordResponse(
+            val id: Int = 0,
+            val content: String = "",
+            val isPositive: Boolean = false,
+        )
+    }
+
+    data class ReviewFilterResponse(
+        val rowId: Int = 0,
+        val seatNumber: Int = 0,
+    )
+}

--- a/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/BlockReviewResponse.kt
+++ b/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/BlockReviewResponse.kt
@@ -1,5 +1,8 @@
 package com.depromeet.domain.entity.response.viewfinder
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 
 data class BlockReviewResponse(
     val keywords: List<KeywordResponse> = emptyList(),
@@ -13,7 +16,8 @@ data class BlockReviewResponse(
 ) {
     data class KeywordResponse(
         val content: String = "",
-        val count: Int = 0
+        val count: Int = 0,
+        val isPositive: Boolean = false
     )
 
     data class ReviewResponse(
@@ -28,19 +32,20 @@ data class BlockReviewResponse(
         val createdAt: String = "",
         val updatedAt: String = "",
         val images: List<ReviewImageResponse> = emptyList(),
-        val keywords: List<ReviewKeywordResponse> = emptyList(),
-
-        ) {
+        val keywords: List<KeywordResponse> = emptyList(),
+    ) {
         data class ReviewImageResponse(
             val id: Int = 0,
             val url: String = "",
         )
 
-        data class ReviewKeywordResponse(
-            val id: Int = 0,
-            val content: String = "",
-            val isPositive: Boolean = false,
-        )
+        fun formattedDate(): String {
+            val localDate = LocalDate.parse(date)
+
+            val formatter = DateTimeFormatter.ofPattern("M월d일")
+            val formattedDate = localDate.format(formatter)
+            return formattedDate
+        }
     }
 
     data class ReviewFilterResponse(

--- a/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/StadiumResponse.kt
+++ b/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/StadiumResponse.kt
@@ -1,7 +1,7 @@
 package com.depromeet.domain.entity.response.viewfinder
 
 data class StadiumResponse(
-    val id: Int = 0,
+    val id: Int,
     val name: String = "",
     val homeTeams: List<StadiumsResponse.HomeTeamsResponse> = emptyList(),
     val thumbnail: String = "",

--- a/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/StadiumResponse.kt
+++ b/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/StadiumResponse.kt
@@ -1,0 +1,9 @@
+package com.depromeet.domain.entity.response.viewfinder
+
+data class StadiumResponse(
+    val id: Int = 0,
+    val name: String = "",
+    val homeTeams: List<StadiumsResponse.HomeTeamsResponse> = emptyList(),
+    val thumbnail: String = "",
+    val stadiumUrl: String = ""
+)

--- a/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/StadiumsResponse.kt
+++ b/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/StadiumsResponse.kt
@@ -1,0 +1,21 @@
+package com.depromeet.domain.entity.response.viewfinder
+
+data class StadiumsResponse(
+    val id: Int = 0,
+    val name: String = "",
+    val homeTeams: List<HomeTeamsResponse> = emptyList(),
+    val thumbnail: String = "",
+    val isActive: Boolean = false,
+) {
+    data class HomeTeamsResponse(
+        val id: Int = 0,
+        val alias: String = "",
+        val color: ColorResponse = ColorResponse(),
+    ) {
+        data class ColorResponse(
+            val red: Int = 0,
+            val green: Int = 0,
+            val blue: Int = 0,
+        )
+    }
+}

--- a/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/StadiumsResponse.kt
+++ b/domain/src/main/java/com/depromeet/domain/entity/response/viewfinder/StadiumsResponse.kt
@@ -1,14 +1,14 @@
 package com.depromeet.domain.entity.response.viewfinder
 
 data class StadiumsResponse(
-    val id: Int = 0,
+    val id: Int,
     val name: String = "",
     val homeTeams: List<HomeTeamsResponse> = emptyList(),
     val thumbnail: String = "",
     val isActive: Boolean = false,
 ) {
     data class HomeTeamsResponse(
-        val id: Int = 0,
+        val id: Int,
         val alias: String = "",
         val color: ColorResponse = ColorResponse(),
     ) {

--- a/domain/src/main/java/com/depromeet/domain/repository/ViewfinderRepository.kt
+++ b/domain/src/main/java/com/depromeet/domain/repository/ViewfinderRepository.kt
@@ -1,9 +1,11 @@
 package com.depromeet.domain.repository
 
+import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
 import com.depromeet.domain.entity.response.viewfinder.StadiumResponse
 import com.depromeet.domain.entity.response.viewfinder.StadiumsResponse
 
 interface ViewfinderRepository {
     suspend fun getStadiums(): List<StadiumsResponse>
     suspend fun getStadium(id : Int) : Result<StadiumResponse>
+    suspend fun getBlockReviews(stadiumId:Int, blockId: String): Result<BlockReviewResponse>
 }

--- a/domain/src/main/java/com/depromeet/domain/repository/ViewfinderRepository.kt
+++ b/domain/src/main/java/com/depromeet/domain/repository/ViewfinderRepository.kt
@@ -1,0 +1,9 @@
+package com.depromeet.domain.repository
+
+import com.depromeet.domain.entity.response.viewfinder.StadiumResponse
+import com.depromeet.domain.entity.response.viewfinder.StadiumsResponse
+
+interface ViewfinderRepository {
+    suspend fun getStadiums(): List<StadiumsResponse>
+    suspend fun getStadium(id : Int) : Result<StadiumResponse>
+}

--- a/domain/src/main/java/com/depromeet/domain/repository/ViewfinderRepository.kt
+++ b/domain/src/main/java/com/depromeet/domain/repository/ViewfinderRepository.kt
@@ -5,7 +5,7 @@ import com.depromeet.domain.entity.response.viewfinder.StadiumResponse
 import com.depromeet.domain.entity.response.viewfinder.StadiumsResponse
 
 interface ViewfinderRepository {
-    suspend fun getStadiums(): List<StadiumsResponse>
+    suspend fun getStadiums(): Result<List<StadiumsResponse>>
     suspend fun getStadium(id : Int) : Result<StadiumResponse>
     suspend fun getBlockReviews(stadiumId:Int, blockId: String): Result<BlockReviewResponse>
 }

--- a/domain/src/main/java/com/depromeet/domain/repository/WebSvgRepository.kt
+++ b/domain/src/main/java/com/depromeet/domain/repository/WebSvgRepository.kt
@@ -1,5 +1,5 @@
 package com.depromeet.domain.repository
 
 interface WebSvgRepository {
-    suspend fun downloadFileWithDynamicUrlAsync(url: String): String
+    suspend fun downloadFileWithDynamicUrlAsync(url: String): Result<String>
 }

--- a/presentation/src/main/java/com/depromeet/presentation/mapper/KeywordMapper.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/mapper/KeywordMapper.kt
@@ -1,0 +1,10 @@
+package com.depromeet.presentation.mapper
+
+import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
+import com.depromeet.presentation.viewfinder.sample.Keyword
+
+fun BlockReviewResponse.KeywordResponse.toKeyword() = Keyword(
+    message = content,
+    like = count,
+    type = if (isPositive) 0 else 1
+)

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumActivity.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumActivity.kt
@@ -26,7 +26,8 @@ class StadiumActivity : BaseActivity<ActivityStadiumBinding>({
     ActivityStadiumBinding.inflate(it)
 }) {
     companion object {
-        const val STADIUM_AREA = "stadium_area"
+        const val STADIUM_ID = "stadium_id"
+        const val STADIUM_BLOCK_ID = "stadium_block_id"
         private const val BASE_URL = "file:///android_asset/web/"
         private const val ENCODING_UTF8 = "UTF-8"
         private const val MIME_TYPE_TEXT_HTML = "text/html"
@@ -62,6 +63,7 @@ class StadiumActivity : BaseActivity<ActivityStadiumBinding>({
                 is UiState.Failure -> toast(stadium.msg)
                 is UiState.Loading -> toast("로딩 중")
                 is UiState.Success -> {
+                    viewModel.stadiumId = stadium.data.id
                     with(binding) {
                         tvStadiumTitle.text = stadium.data.name
                         ivStadium.load(stadium.data.thumbnail) {
@@ -167,9 +169,10 @@ class StadiumActivity : BaseActivity<ActivityStadiumBinding>({
         }
     }
 
-    private fun startToStadiumDetailActivity(fromWeb: String) {
+    private fun startToStadiumDetailActivity(id: String) {
         Intent(this, StadiumDetailActivity::class.java).apply {
-            putExtra(STADIUM_AREA, fromWeb)
+            putExtra(STADIUM_ID, viewModel.stadiumId)
+            putExtra(STADIUM_BLOCK_ID, id)
         }.let(::startActivity)
     }
 

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumActivity.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumActivity.kt
@@ -69,6 +69,7 @@ class StadiumActivity : BaseActivity<ActivityStadiumBinding>({
                         ivStadium.load(stadium.data.thumbnail) {
                             transformations(RoundedCornersTransformation(10f))
                         }
+                        llStadiumTeamLabel.removeAllViews()
                         stadium.data.homeTeams.forEach { homeTeam ->
                             llStadiumTeamLabel.addView(
                                 SpotTeamLabel(this@StadiumActivity).apply {

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumActivity.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumActivity.kt
@@ -16,9 +16,7 @@ import com.depromeet.core.base.BaseActivity
 import com.depromeet.core.state.UiState
 import com.depromeet.designsystem.SpotTeamLabel
 import com.depromeet.presentation.databinding.ActivityStadiumBinding
-import com.depromeet.presentation.extension.getCompatibleParcelableExtra
 import com.depromeet.presentation.extension.toast
-import com.depromeet.presentation.viewfinder.sample.Stadium
 import com.depromeet.presentation.viewfinder.viewmodel.StadiumViewModel
 import com.depromeet.presentation.viewfinder.web.AndroidBridge
 import dagger.hilt.android.AndroidEntryPoint
@@ -41,44 +39,72 @@ class StadiumActivity : BaseActivity<ActivityStadiumBinding>({
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        getStadiumExtra()
-        configureWebViewSetting()
-        interactionWebView()
+        initView()
         initEvent()
-
-        viewModel.downloadFileFromServer(SVG_URL)
         observeData()
     }
 
+    private fun initView() {
+        getStadiumIdExtra()
+        configureWebViewSetting()
+    }
+
     private fun initEvent() {
-        binding.spotAppbar.setNavigationOnClickListener {
-            finish()
-        }
+        interactionWebView()
+        onClickBack()
+        onClickClose()
+    }
 
-        binding.spotAppbar.setMenuOnClickListener {
-            // go to main activity
+    private fun observeData() {
+        viewModel.stadium.asLiveData().observe(this) { stadium ->
+            when (stadium) {
+                is UiState.Empty -> Unit
+                is UiState.Failure -> toast(stadium.msg)
+                is UiState.Loading -> toast("로딩 중")
+                is UiState.Success -> {
+                    with(binding) {
+                        tvStadiumTitle.text = stadium.data.name
+                        ivStadium.load(stadium.data.thumbnail) {
+                            transformations(RoundedCornersTransformation(10f))
+                        }
+                        stadium.data.homeTeams.forEach { homeTeam ->
+                            llStadiumTeamLabel.addView(
+                                SpotTeamLabel(this@StadiumActivity).apply {
+                                    teamType = homeTeam.alias
+                                }
+                            )
+                        }
+                    }
+                    viewModel.downloadFileFromServer(stadium.data.stadiumUrl)
+                }
+            }
         }
+        viewModel.htmlBody.asLiveData().observe(this) { uiState ->
+            when (uiState) {
+                is UiState.Empty -> Unit
+                is UiState.Failure -> {
+                    toast("실패")
+                }
 
-        binding.ivClose.setOnClickListener {
-            binding.clZoomDescription.visibility = View.INVISIBLE
+                is UiState.Loading -> {
+                    toast("로딩중")
+                }
+
+                is UiState.Success -> {
+                    binding.wvStadium.loadDataWithBaseURL(
+                        BASE_URL, uiState.data, MIME_TYPE_TEXT_HTML,
+                        ENCODING_UTF8, null
+                    )
+                    binding.wvStadium.webChromeClient = WebChromeClient()
+                }
+            }
         }
     }
 
-    private fun getStadiumExtra() {
-        intent?.getCompatibleParcelableExtra<Stadium>(StadiumSelectionActivity.STADIUM_EXTRA)
-            ?.let { stadium ->
-                binding.tvStadiumTitle.text = stadium.title
-                binding.ivStadium.load(stadium.imageUrl) {
-                    transformations(RoundedCornersTransformation(10f))
-                }
-                stadium.team.forEach { label ->
-                    binding.llStadiumTeamLabel.addView(
-                        SpotTeamLabel(this).apply {
-                            teamType = label
-                        }
-                    )
-                }
-            }
+    private fun getStadiumIdExtra() {
+        intent?.getIntExtra(StadiumSelectionActivity.STADIUM_EXTRA_ID, 0)?.let { stadiumId ->
+            viewModel.getStadium(stadiumId)
+        } ?: return
     }
 
     private fun configureWebViewSetting() {
@@ -125,26 +151,19 @@ class StadiumActivity : BaseActivity<ActivityStadiumBinding>({
         }
     }
 
-    private fun observeData() {
-        viewModel.htmlBody.asLiveData().observe(this) { uiState ->
-            when (uiState) {
-                is UiState.Empty -> Unit
-                is UiState.Failure -> {
-                    toast("실패")
-                }
+    private fun onClickBack() {
+        binding.spotAppbar.setNavigationOnClickListener {
+            finish()
+        }
+    }
 
-                is UiState.Loading -> {
-                    toast("로딩중")
-                }
+    private fun onClickClose() {
+        binding.spotAppbar.setMenuOnClickListener {
+            // go to main activity
+        }
 
-                is UiState.Success -> {
-                    binding.wvStadium.loadDataWithBaseURL(
-                        BASE_URL, uiState.data, MIME_TYPE_TEXT_HTML,
-                        ENCODING_UTF8, null
-                    )
-                    binding.wvStadium.webChromeClient = WebChromeClient()
-                }
-            }
+        binding.ivClose.setOnClickListener {
+            binding.clZoomDescription.visibility = View.INVISIBLE
         }
     }
 

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumDetailActivity.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumDetailActivity.kt
@@ -13,8 +13,6 @@ import com.depromeet.presentation.viewfinder.compose.StadiumDetailScreen
 import com.depromeet.presentation.viewfinder.dialog.ReportDialog
 import com.depromeet.presentation.viewfinder.dialog.StadiumFilterMonthsDialog
 import com.depromeet.presentation.viewfinder.dialog.StadiumSelectSeatDialog
-import com.depromeet.presentation.viewfinder.sample.ReviewContent
-import com.depromeet.presentation.viewfinder.sample.stadiums
 import com.depromeet.presentation.viewfinder.viewmodel.StadiumDetailViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -23,7 +21,7 @@ class StadiumDetailActivity : BaseActivity<ActivityStadiumDetailBinding>({
     ActivityStadiumDetailBinding.inflate(it)
 }) {
     companion object {
-        const val REVIEW_PICTURE_CONTENT = "review_picture_content"
+        const val REVIEW_ID = "review_id"
         const val STADIUM_HEADER = "stadium_header"
         const val STADIUM_REVIEW_CONTENT = "stadium_review_content"
     }
@@ -89,7 +87,7 @@ class StadiumDetailActivity : BaseActivity<ActivityStadiumDetailBinding>({
 
     private fun startToStadiumDetailPictureFragment(reviewContent: BlockReviewResponse.ReviewResponse) {
         val fragment = StadiumDetailPictureFragment.newInstance().apply {
-            arguments = bundleOf(REVIEW_PICTURE_CONTENT to reviewContent)
+            arguments = bundleOf(REVIEW_ID to reviewContent.id)
         }
 
         supportFragmentManager.commit {

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumDetailActivity.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumDetailActivity.kt
@@ -6,6 +6,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.commit
 import com.depromeet.core.base.BaseActivity
+import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
 import com.depromeet.presentation.R
 import com.depromeet.presentation.databinding.ActivityStadiumDetailBinding
 import com.depromeet.presentation.viewfinder.compose.StadiumDetailScreen
@@ -86,7 +87,7 @@ class StadiumDetailActivity : BaseActivity<ActivityStadiumDetailBinding>({
         )
     }
 
-    private fun startToStadiumDetailPictureFragment(reviewContent: ReviewContent) {
+    private fun startToStadiumDetailPictureFragment(reviewContent: BlockReviewResponse.ReviewResponse) {
         val fragment = StadiumDetailPictureFragment.newInstance().apply {
             arguments = bundleOf(REVIEW_PICTURE_CONTENT to reviewContent)
         }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumDetailActivity.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumDetailActivity.kt
@@ -13,6 +13,7 @@ import com.depromeet.presentation.viewfinder.dialog.ReportDialog
 import com.depromeet.presentation.viewfinder.dialog.StadiumFilterMonthsDialog
 import com.depromeet.presentation.viewfinder.dialog.StadiumSelectSeatDialog
 import com.depromeet.presentation.viewfinder.sample.ReviewContent
+import com.depromeet.presentation.viewfinder.sample.stadiums
 import com.depromeet.presentation.viewfinder.viewmodel.StadiumDetailViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -30,7 +31,41 @@ class StadiumDetailActivity : BaseActivity<ActivityStadiumDetailBinding>({
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        initView()
+        initEvent()
 
+        binding.composeView.setContent {
+            StadiumDetailScreen(
+                viewModel = viewModel,
+                onClickReviewPicture = { reviewContent ->
+                    startToStadiumDetailPictureFragment(reviewContent)
+                },
+                onClickSelectSeat = {
+                    startToBottomSheetDialog(
+                        StadiumSelectSeatDialog.newInstance(),
+                        StadiumSelectSeatDialog.TAG
+                    )
+                },
+                onClickFilterMonthly = {
+                    startToBottomSheetDialog(
+                        StadiumFilterMonthsDialog.newInstance(),
+                        StadiumFilterMonthsDialog.TAG
+                    )
+                },
+                onClickReport = {
+                    startToBottomSheetDialog(ReportDialog.newInstance(), ReportDialog.TAG)
+                }
+            )
+        }
+    }
+
+    private fun initView() {
+        getIdExtra { stadiumId, blockId ->
+            viewModel.getBlockReviews(stadiumId, blockId)
+        }
+    }
+
+    private fun initEvent() {
         binding.spotAppbar.setNavigationOnClickListener {
             finish()
         }
@@ -42,24 +77,13 @@ class StadiumDetailActivity : BaseActivity<ActivityStadiumDetailBinding>({
         binding.btnUp.setOnClickListener {
             viewModel.updateScrollState(true)
         }
+    }
 
-        binding.composeView.setContent {
-            StadiumDetailScreen(
-                viewModel = viewModel,
-                onClickReviewPicture = { reviewContent ->
-                    startToStadiumDetailPictureFragment(reviewContent)
-                },
-                onClickSelectSeat = {
-                    startToBottomSheetDialog(StadiumSelectSeatDialog.newInstance(), StadiumSelectSeatDialog.TAG)
-                },
-                onClickFilterMonthly = {
-                    startToBottomSheetDialog(StadiumFilterMonthsDialog.newInstance(), StadiumFilterMonthsDialog.TAG)
-                },
-                onClickReport = {
-                    startToBottomSheetDialog(ReportDialog.newInstance(), ReportDialog.TAG)
-                }
-            )
-        }
+    private fun getIdExtra(callback: (stadiumId: Int, blockId: String) -> Unit) {
+        callback(
+            intent?.getIntExtra(StadiumActivity.STADIUM_ID, 0) ?: 0,
+            intent?.getStringExtra(StadiumActivity.STADIUM_BLOCK_ID) ?: ""
+        )
     }
 
     private fun startToStadiumDetailPictureFragment(reviewContent: ReviewContent) {

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumDetailPictureFragment.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/StadiumDetailPictureFragment.kt
@@ -2,15 +2,16 @@ package com.depromeet.presentation.viewfinder
 
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
 import com.depromeet.core.base.BindingFragment
 import com.depromeet.presentation.R
 import com.depromeet.presentation.databinding.FragmentStadiumDetailPictureBinding
-import com.depromeet.presentation.extension.getCompatibleParcelableExtra
 import com.depromeet.presentation.viewfinder.compose.detailpicture.StadiumDetailPictureScreen
-import com.depromeet.presentation.viewfinder.sample.ReviewContent
-import com.depromeet.presentation.viewfinder.sample.reviewContents
+import com.depromeet.presentation.viewfinder.viewmodel.StadiumDetailViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class StadiumDetailPictureFragment : BindingFragment<FragmentStadiumDetailPictureBinding>(
     R.layout.fragment_stadium_detail_picture, FragmentStadiumDetailPictureBinding::inflate
 ) {
@@ -26,20 +27,35 @@ class StadiumDetailPictureFragment : BindingFragment<FragmentStadiumDetailPictur
         }
     }
 
+    private val stadiumDetailViewModel: StadiumDetailViewModel by activityViewModels()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val area =
-            arguments?.getCompatibleParcelableExtra<ReviewContent>(StadiumDetailActivity.REVIEW_PICTURE_CONTENT)
+        initView()
+        initEvent()
+    }
 
+    private fun initView() {
+        getReviewIdExtra { reviewId ->
+            binding.cvReviewContent.setContent {
+                StadiumDetailPictureScreen(
+                    reviewId = reviewId,
+                    stadiumDetailViewModel = stadiumDetailViewModel,
+                )
+            }
+        }
+    }
+
+    private fun initEvent() {
         binding.spotAppbar.setNavigationOnClickListener {
             removeFragment()
         }
 
-        binding.cvReviewContent.setContent {
-            StadiumDetailPictureScreen(
-                reviews = reviewContents,
-            )
-        }
+    }
+
+    private fun getReviewIdExtra(callback: (id: Long) -> Unit) {
+        val reviewId = arguments?.getLong(StadiumDetailActivity.REVIEW_ID) ?: return
+        callback(reviewId)
     }
 
     private fun removeFragment() {

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/adapter/StadiumSelectionAdapter.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/adapter/StadiumSelectionAdapter.kt
@@ -6,19 +6,19 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.depromeet.domain.entity.response.viewfinder.StadiumsResponse
 import com.depromeet.presentation.databinding.ItemStadiumSelectionBinding
 import com.depromeet.presentation.util.ItemDiffCallback
-import com.depromeet.presentation.viewfinder.sample.Stadium
 import com.depromeet.presentation.viewfinder.viewholder.StadiumSelectionViewHolder
 
-class StadiumSelectionAdapter : ListAdapter<Stadium, StadiumSelectionViewHolder>(
-    ItemDiffCallback<Stadium>(
+class StadiumSelectionAdapter : ListAdapter<StadiumsResponse, StadiumSelectionViewHolder>(
+    ItemDiffCallback<StadiumsResponse>(
         onItemsTheSame = { old, new -> old.id == new.id },
         onContentsTheSame = { old, new -> old == new }
     )
 ) {
     interface OnItemStadiumClickListener {
-        fun onItemStadiumClick(item: Stadium)
+        fun onItemStadiumClick(stadiums: StadiumsResponse)
     }
 
     var itemStadiumClickListener: OnItemStadiumClickListener? = null

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumDetailScreen.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumDetailScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.depromeet.core.state.UiState
+import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
+import com.depromeet.presentation.mapper.toKeyword
 import com.depromeet.presentation.viewfinder.StadiumDetailActivity
 import com.depromeet.presentation.viewfinder.sample.ReviewContent
 import com.depromeet.presentation.viewfinder.sample.Stadium
@@ -36,7 +38,7 @@ fun StadiumDetailScreen(
     context: Context = LocalContext.current,
     modifier: Modifier = Modifier,
     viewModel: StadiumDetailViewModel = viewModel(),
-    onClickReviewPicture: (ReviewContent) -> Unit,
+    onClickReviewPicture: (BlockReviewResponse.ReviewResponse) -> Unit,
     onClickSelectSeat: () -> Unit,
     onClickFilterMonthly: () -> Unit,
     onClickReport: () -> Unit
@@ -76,14 +78,14 @@ fun StadiumDetailScreen(
                         )
                     }
 
-                    if (review.reviewContents.isEmpty()) {
+                    if (state.data.reviews.isEmpty()) {
                         item(StadiumDetailActivity.STADIUM_REVIEW_CONTENT) {
                             StadiumEmptyReviewContent()
                             Spacer(modifier = Modifier.height(40.dp))
                         }
                     } else {
                         itemsIndexed(
-                            items = review.reviewContents
+                            items = state.data.reviews
                         ) { _, reviewContent ->
                             StadiumReviewContent(
                                 context = context,

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumDetailScreen.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumDetailScreen.kt
@@ -26,10 +26,8 @@ import com.depromeet.core.state.UiState
 import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
 import com.depromeet.presentation.mapper.toKeyword
 import com.depromeet.presentation.viewfinder.StadiumDetailActivity
-import com.depromeet.presentation.viewfinder.sample.ReviewContent
 import com.depromeet.presentation.viewfinder.sample.Stadium
 import com.depromeet.presentation.viewfinder.sample.StadiumArea
-import com.depromeet.presentation.viewfinder.sample.review
 import com.depromeet.presentation.viewfinder.viewmodel.StadiumDetailViewModel
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumDetailScreen.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumDetailScreen.kt
@@ -62,7 +62,7 @@ fun StadiumDetailScreen(
                             isMore = isMore,
                             stadium = Stadium(1, "서울 잠실 야구장", emptyList(), "", false),
                             stadiumArea = StadiumArea("1루", 207, "오렌지석"),
-                            keywords = state.data.keywords,
+                            keywords = state.data.keywords.map { it.toKeyword() },
                             onChangeIsMore = { isMore = it },
                             onClickSelectSeat = onClickSelectSeat
                         )

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumHeaderContent.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumHeaderContent.kt
@@ -16,12 +16,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
 import com.depromeet.presentation.viewfinder.sample.Keyword
 import com.depromeet.presentation.viewfinder.sample.Seat
 import com.depromeet.presentation.viewfinder.sample.Stadium
 import com.depromeet.presentation.viewfinder.sample.StadiumArea
-import com.depromeet.presentation.viewfinder.sample.keywords
 import com.depromeet.presentation.viewfinder.sample.pictures
 
 @Composable
@@ -30,7 +28,7 @@ fun StadiumHeaderContent(
     stadium: Stadium,
     isMore: Boolean,
     stadiumArea: StadiumArea,
-    keywords: List<BlockReviewResponse.KeywordResponse>,
+    keywords: List<Keyword>,
     modifier: Modifier = Modifier,
     onChangeIsMore: (Boolean) -> Unit,
     onClickSelectSeat: () -> Unit
@@ -85,18 +83,9 @@ private fun StadiumHeaderContentPreview() {
         stadium = Stadium(1, "서울 잠실 야구장", emptyList(), "", false),
         stadiumArea = StadiumArea("1루", 207, "오렌지석"),
         keywords = listOf(
-            BlockReviewResponse.KeywordResponse(
-                content = "서서 응원하는 존",
-                count = 5
-            ),
-            BlockReviewResponse.KeywordResponse(
-                content = "온종일 햇빛 존",
-                count = 4
-            ),
-            BlockReviewResponse.KeywordResponse(
-                content = "서서 응원하는 존",
-                count = 3
-            )
+            Keyword(message = "서서 응원하는 존", like = 5, type = 0),
+            Keyword(message = "서서 응원하는 존", like = 5, type = 0),
+            Keyword(message = "서서 응원하는 존", like = 5, type = 0),
         ),
         onChangeIsMore = {},
         onClickSelectSeat = {}
@@ -112,26 +101,11 @@ private fun StadiumHeaderContentIsMorePreview() {
         stadium = Stadium(1, "서울 잠실 야구장", emptyList(), "", false),
         stadiumArea = StadiumArea("1루", 207, "오렌지석"),
         keywords = listOf(
-            BlockReviewResponse.KeywordResponse(
-                content = "서서 응원하는 존",
-                count = 5
-            ),
-            BlockReviewResponse.KeywordResponse(
-                content = "온종일 햇빛 존",
-                count = 4
-            ),
-            BlockReviewResponse.KeywordResponse(
-                content = "서서 응원하는 존",
-                count = 3
-            ),
-            BlockReviewResponse.KeywordResponse(
-                content = "서서 응원하는 존",
-                count = 2
-            ),
-            BlockReviewResponse.KeywordResponse(
-                content = "서서 응원하는 존",
-                count = 1
-            )
+            Keyword(message = "서서 응원하는 존", like = 5, type = 0),
+            Keyword(message = "서서 응원하는 존", like = 5, type = 0),
+            Keyword(message = "서서 응원하는 존", like = 5, type = 0),
+            Keyword(message = "서서 응원하는 존", like = 5, type = 0),
+            Keyword(message = "서서 응원하는 존", like = 5, type = 0),
         ),
         onChangeIsMore = {},
         onClickSelectSeat = {}

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumHeaderContent.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumHeaderContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
 import com.depromeet.presentation.viewfinder.sample.Keyword
 import com.depromeet.presentation.viewfinder.sample.Seat
 import com.depromeet.presentation.viewfinder.sample.Stadium
@@ -29,7 +30,7 @@ fun StadiumHeaderContent(
     stadium: Stadium,
     isMore: Boolean,
     stadiumArea: StadiumArea,
-    keywords: List<Keyword>,
+    keywords: List<BlockReviewResponse.KeywordResponse>,
     modifier: Modifier = Modifier,
     onChangeIsMore: (Boolean) -> Unit,
     onClickSelectSeat: () -> Unit
@@ -83,7 +84,20 @@ private fun StadiumHeaderContentPreview() {
         isMore = false,
         stadium = Stadium(1, "서울 잠실 야구장", emptyList(), "", false),
         stadiumArea = StadiumArea("1루", 207, "오렌지석"),
-        keywords = keywords,
+        keywords = listOf(
+            BlockReviewResponse.KeywordResponse(
+                content = "서서 응원하는 존",
+                count = 5
+            ),
+            BlockReviewResponse.KeywordResponse(
+                content = "온종일 햇빛 존",
+                count = 4
+            ),
+            BlockReviewResponse.KeywordResponse(
+                content = "서서 응원하는 존",
+                count = 3
+            )
+        ),
         onChangeIsMore = {},
         onClickSelectSeat = {}
     )
@@ -97,7 +111,28 @@ private fun StadiumHeaderContentIsMorePreview() {
         isMore = true,
         stadium = Stadium(1, "서울 잠실 야구장", emptyList(), "", false),
         stadiumArea = StadiumArea("1루", 207, "오렌지석"),
-        keywords = keywords,
+        keywords = listOf(
+            BlockReviewResponse.KeywordResponse(
+                content = "서서 응원하는 존",
+                count = 5
+            ),
+            BlockReviewResponse.KeywordResponse(
+                content = "온종일 햇빛 존",
+                count = 4
+            ),
+            BlockReviewResponse.KeywordResponse(
+                content = "서서 응원하는 존",
+                count = 3
+            ),
+            BlockReviewResponse.KeywordResponse(
+                content = "서서 응원하는 존",
+                count = 2
+            ),
+            BlockReviewResponse.KeywordResponse(
+                content = "서서 응원하는 존",
+                count = 1
+            )
+        ),
         onChangeIsMore = {},
         onClickSelectSeat = {}
     )

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumHeaderContent.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumHeaderContent.kt
@@ -65,6 +65,7 @@ fun StadiumHeaderContent(
             )
             CustomTooltip(modifier = Modifier.zIndex(1f))
         }
+        Spacer(modifier = Modifier.height(10.dp))
         Divider(
             color = Color(0xFFF4F4F4),
             thickness = 10.dp,

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumKeywordContent.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumKeywordContent.kt
@@ -28,7 +28,7 @@ import com.depromeet.presentation.viewfinder.sample.Keyword
 @Composable
 fun StadiumKeywordContent(
     isMore: Boolean,
-    keywords: List<BlockReviewResponse.KeywordResponse>,
+    keywords: List<Keyword>,
     modifier: Modifier = Modifier,
     onChangeIsMore: (isMore: Boolean) -> Unit,
 ) {
@@ -142,7 +142,9 @@ private fun StadiumKeywordContentOnePreview() {
     ) {
         StadiumKeywordContent(
             isMore = false,
-            keywords = listOf(BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", count = 44))
+            keywords = listOf(
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+            )
         ) {}
     }
 }
@@ -154,8 +156,8 @@ private fun StadiumKeywordContentTwoPreview() {
         StadiumKeywordContent(
             isMore = false,
             keywords = listOf(
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
             )
         ) {}
     }
@@ -168,9 +170,9 @@ private fun StadiumKeywordContentThreePreview() {
         StadiumKeywordContent(
             isMore = false,
             keywords = listOf(
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
             )
         ) {}
     }
@@ -183,10 +185,10 @@ private fun StadiumKeywordContentFourPreview() {
         StadiumKeywordContent(
             isMore = false,
             keywords = listOf(
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
             )
         ) {}
     }
@@ -199,11 +201,11 @@ private fun StadiumKeywordContentFivePreview() {
         StadiumKeywordContent(
             isMore = false,
             keywords = listOf(
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
             )
         ) {}
     }
@@ -219,11 +221,12 @@ private fun StadiumKeywordContentFiveMorePreview() {
         StadiumKeywordContent(
             isMore = true,
             keywords = listOf(
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
-                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
+                Keyword("🙍‍서서 응원하는 존", 44, 1),
             )
         ) {}
     }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumKeywordContent.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumKeywordContent.kt
@@ -21,13 +21,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
+import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
 import com.depromeet.presentation.R
 import com.depromeet.presentation.viewfinder.sample.Keyword
 
 @Composable
 fun StadiumKeywordContent(
     isMore: Boolean,
-    keywords: List<Keyword>,
+    keywords: List<BlockReviewResponse.KeywordResponse>,
     modifier: Modifier = Modifier,
     onChangeIsMore: (isMore: Boolean) -> Unit,
 ) {
@@ -141,7 +142,7 @@ private fun StadiumKeywordContentOnePreview() {
     ) {
         StadiumKeywordContent(
             isMore = false,
-            keywords = listOf(Keyword("🙍‍서서 응원하는 존", 44, 0))
+            keywords = listOf(BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", count = 44))
         ) {}
     }
 }
@@ -153,8 +154,8 @@ private fun StadiumKeywordContentTwoPreview() {
         StadiumKeywordContent(
             isMore = false,
             keywords = listOf(
-                Keyword("🙍‍서서 응원하는 존", 44, 0),
-                Keyword("☀️ 온종일 햇빛 존", 44, 1),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
             )
         ) {}
     }
@@ -167,9 +168,9 @@ private fun StadiumKeywordContentThreePreview() {
         StadiumKeywordContent(
             isMore = false,
             keywords = listOf(
-                Keyword("🙍‍서서 응원하는 존", 44, 0),
-                Keyword("☀️ 온종일 햇빛 존", 44, 1),
-                Keyword("🙍‍서서 응원하는 존", 44, 0),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
             )
         ) {}
     }
@@ -182,10 +183,10 @@ private fun StadiumKeywordContentFourPreview() {
         StadiumKeywordContent(
             isMore = false,
             keywords = listOf(
-                Keyword("🙍‍서서 응원하는 존", 44, 0),
-                Keyword("☀️ 온종일 햇빛 존", 44, 1),
-                Keyword("🙍‍서서 응원하는 존", 44, 0),
-                Keyword("☀️ 온종일 햇빛 존", 44, 1),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
             )
         ) {}
     }
@@ -198,11 +199,11 @@ private fun StadiumKeywordContentFivePreview() {
         StadiumKeywordContent(
             isMore = false,
             keywords = listOf(
-                Keyword("🙍‍서서 응원하는 존", 44, 0),
-                Keyword("☀️ 온종일 햇빛 존", 44, 1),
-                Keyword("🙍‍서서 응원하는 존", 44, 0),
-                Keyword("☀️ 온종일 햇빛 존", 44, 1),
-                Keyword("🙍‍서서 응원하는 존", 44, 0),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
             )
         ) {}
     }
@@ -218,11 +219,11 @@ private fun StadiumKeywordContentFiveMorePreview() {
         StadiumKeywordContent(
             isMore = true,
             keywords = listOf(
-                Keyword("🙍‍서서 응원하는 존", 44, 0),
-                Keyword("☀️ 온종일 햇빛 존", 44, 1),
-                Keyword("🙍‍서서 응원하는 존", 44, 0),
-                Keyword("☀️ 온종일 햇빛 존", 44, 1),
-                Keyword("🙍‍서서 응원하는 존", 44, 0),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
+                BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44),
             )
         ) {}
     }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumKeywordRow.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumKeywordRow.kt
@@ -19,19 +19,18 @@ import com.depromeet.presentation.viewfinder.sample.Keyword
 
 @Composable
 fun StadiumKeywordRow(
-    keyword: BlockReviewResponse.KeywordResponse,
+    keyword: Keyword,
     modifier: Modifier = Modifier
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
             .background(
-//                color = if (keyword.type == 0) {
-//                    Color(0xFFF4F4F4)
-//                } else {
-//                    Color(0xFFFFEAEA)
-//                },
-                color = Color(0xFFF4F4F4),
+                color = if (keyword.type == 0) {
+                    Color(0xFFF4F4F4)
+                } else {
+                    Color(0xFFFFEAEA)
+                },
                 shape = RoundedCornerShape(6.dp)
             )
             .padding(
@@ -41,12 +40,12 @@ fun StadiumKeywordRow(
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Text(
-            text = keyword.content,
+            text = keyword.message,
             fontSize = 14.sp,
             color = Color(0xFF4A4A4A)
         )
         Text(
-            text = keyword.count.toString(),
+            text = keyword.like.toString(),
             fontSize = 14.sp,
             color = Color(0xFF9F9F9F)
         )
@@ -57,6 +56,6 @@ fun StadiumKeywordRow(
 @Composable
 private fun StadiumKeywordRowPreview() {
     StadiumKeywordRow(
-        keyword = BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44)
+        keyword = Keyword("🙍‍서서 응원하는 존", 44, 1)
     )
 }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumKeywordRow.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumKeywordRow.kt
@@ -14,22 +14,25 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
 import com.depromeet.presentation.viewfinder.sample.Keyword
 
 @Composable
 fun StadiumKeywordRow(
-    keyword: Keyword,
+    keyword: BlockReviewResponse.KeywordResponse,
     modifier: Modifier = Modifier
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
             .background(
-                color = if (keyword.type == 0) {
-                    Color(0xFFF4F4F4)
-                } else {
-                    Color(0xFFFFEAEA)
-                }, shape = RoundedCornerShape(6.dp)
+//                color = if (keyword.type == 0) {
+//                    Color(0xFFF4F4F4)
+//                } else {
+//                    Color(0xFFFFEAEA)
+//                },
+                color = Color(0xFFF4F4F4),
+                shape = RoundedCornerShape(6.dp)
             )
             .padding(
                 vertical = 10.dp, horizontal = 16.dp
@@ -38,12 +41,12 @@ fun StadiumKeywordRow(
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Text(
-            text = keyword.message,
+            text = keyword.content,
             fontSize = 14.sp,
             color = Color(0xFF4A4A4A)
         )
         Text(
-            text = keyword.like.toString(),
+            text = keyword.count.toString(),
             fontSize = 14.sp,
             color = Color(0xFF9F9F9F)
         )
@@ -54,6 +57,6 @@ fun StadiumKeywordRow(
 @Composable
 private fun StadiumKeywordRowPreview() {
     StadiumKeywordRow(
-        keyword = Keyword("🙍‍서서 응원하는 존", 44, 0)
+        keyword = BlockReviewResponse.KeywordResponse("🙍‍서서 응원하는 존", 44)
     )
 }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumReviewContent.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumReviewContent.kt
@@ -135,7 +135,7 @@ fun StadiumReviewContent(
         )
         Spacer(modifier = Modifier.height(8.dp))
         KeywordFlowRow(
-            keywords = reviewContent.keyword,
+            keywords = reviewContent.keywords.map { it.toKeyword() },
             modifier = Modifier.padding(start = 36.dp, end = 16.dp),
         )
     }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumReviewContent.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/StadiumReviewContent.kt
@@ -30,21 +30,24 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
 import com.depromeet.presentation.R
+import com.depromeet.presentation.mapper.toKeyword
 import com.depromeet.presentation.viewfinder.sample.ReviewContent
 import com.depromeet.presentation.viewfinder.sample.reviewContents
 
 @Composable
 fun StadiumReviewContent(
     context: Context,
-    reviewContent: ReviewContent,
+    reviewContent: BlockReviewResponse.ReviewResponse,
     modifier: Modifier = Modifier,
-    onClick: (reviewContent: ReviewContent) -> Unit,
+    onClick: (reviewContent: BlockReviewResponse.ReviewResponse) -> Unit,
     onClickReport: () -> Unit
 ) {
     Column(
@@ -62,7 +65,7 @@ fun StadiumReviewContent(
             ) {
                 AsyncImage(
                     model = ImageRequest.Builder(context)
-                        .data(reviewContent.profile)
+//                        .data(reviewContent.profile)
                         .build(),
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
@@ -73,12 +76,16 @@ fun StadiumReviewContent(
                 )
                 Spacer(modifier = Modifier.width(4.dp))
                 Text(
-                    text = reviewContent.user,
+//                    text = reviewContent.user,
+                    text = "test",
                     fontSize = 12.sp,
                     color = Color(0xFF9F9F9F)
                 )
                 Spacer(modifier = Modifier.width(4.dp))
-                LevelCard(level = reviewContent.level)
+                LevelCard(
+//                    level = reviewContent.level
+                    level = 1
+                )
             }
             Icon(
                 painter = painterResource(id = R.drawable.ic_horizontal_dots),
@@ -95,13 +102,15 @@ fun StadiumReviewContent(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "${reviewContent.seat}",
+//                text = "${reviewContent.seat}",
+                text = "207블럭 1열 12번",
                 fontSize = 15.sp,
                 fontWeight = FontWeight.Bold,
                 color = Color(0xFF121212)
             )
             Text(
-                text = "・${reviewContent.date}",
+//                text = "・${reviewContent.date}",
+                text = "・${reviewContent.formattedDate()}",
                 fontSize = 12.sp,
                 color = Color(0xFF9F9F9F)
             )
@@ -113,7 +122,7 @@ fun StadiumReviewContent(
             items(reviewContent.images.size) {
                 AsyncImage(
                     model = ImageRequest.Builder(context)
-                        .data(reviewContent.images[it])
+                        .data(reviewContent.images[it].url)
                         .build(),
                     contentDescription = null,
                     placeholder = ColorPainter(Color.LightGray),
@@ -131,6 +140,8 @@ fun StadiumReviewContent(
             text = reviewContent.content,
             fontSize = 14.sp,
             color = Color(0xFF121212),
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 3,
             modifier = Modifier.padding(start = 36.dp, end = 16.dp)
         )
         Spacer(modifier = Modifier.height(8.dp))
@@ -151,9 +162,46 @@ private fun StadiumReviewContentPreview() {
     ) {
         StadiumReviewContent(
             context = LocalContext.current,
-            reviewContent = reviewContents[0],
+            reviewContent = BlockReviewResponse.ReviewResponse(
+                id = 1,
+                userId = 1,
+                blockId = 1,
+                seatId = 1,
+                rowId = 1,
+                seatNumber = 1,
+                date= "2024-07-13",
+                content = "전체적으로 좋은 경험이었습니다. 다음에 또 오고 싶어요!",
+                images = listOf(
+                    BlockReviewResponse.ReviewResponse.ReviewImageResponse(
+                        id = 1,
+                        url = "https://picsum.photos/200/300"
+                    ),
+                    BlockReviewResponse.ReviewResponse.ReviewImageResponse(
+                        id = 1,
+                        url = "https://picsum.photos/200/300"
+                    ),
+                ),
+                keywords = listOf(
+                    BlockReviewResponse.KeywordResponse(
+                        content = "",
+                        count = 1,
+                        isPositive = false
+                    ),
+                    BlockReviewResponse.KeywordResponse(
+                        content = "",
+                        count = 1,
+                        isPositive = false
+                    ),
+                    BlockReviewResponse.KeywordResponse(
+                        content = "",
+                        count = 1,
+                        isPositive = false
+                    )
+                )
+            ),
             onClick = {},
             onClickReport = {}
         )
+
     }
 }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/detailpicture/StadiumDetailPictureScreen.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/detailpicture/StadiumDetailPictureScreen.kt
@@ -41,21 +41,26 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.depromeet.core.state.UiState
+import com.depromeet.presentation.mapper.toKeyword
 import com.depromeet.presentation.viewfinder.compose.KeywordFlowRow
 import com.depromeet.presentation.viewfinder.compose.LevelCard
-import com.depromeet.presentation.viewfinder.sample.ReviewContent
-import com.depromeet.presentation.viewfinder.sample.pictures
-import com.depromeet.presentation.viewfinder.sample.reviewContents
+import com.depromeet.presentation.viewfinder.viewmodel.StadiumDetailViewModel
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun StadiumDetailPictureScreen(
     context: Context = LocalContext.current,
-    reviews: List<ReviewContent>,
+    stadiumDetailViewModel: StadiumDetailViewModel = viewModel(),
+    reviewId: Long,
     modifier: Modifier = Modifier
 ) {
+    val blockReviews by stadiumDetailViewModel.blockReviews.collectAsStateWithLifecycle()
+
     var isMore by remember {
         mutableStateOf(false)
     }
@@ -68,160 +73,181 @@ fun StadiumDetailPictureScreen(
         mutableStateOf(false)
     }
 
-    val pagerState = rememberPagerState(pageCount = { reviews.size })
-
-    LaunchedEffect(key1 = pagerState) {
-        snapshotFlow { pagerState.currentPage }.collect {
-            isMore = false
-            isMoreButton = false
-            isDimmed = false
-        }
-    }
-
-    VerticalPager(
-        state = pagerState,
-        modifier = modifier
-            .fillMaxSize()
-            .background(Color.White)
-    ) { page ->
-        Box(modifier = Modifier.fillMaxSize()) {
-            AsyncImage(
-                model = ImageRequest.Builder(context)
-                    .data(reviews[page].images.getOrNull(0))
-                    .build(),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .zIndex(1f)
-                    .blur(5.dp)
-            )
-
-            Column(
-                modifier = Modifier
-                    .zIndex(if (isDimmed) 2f else 3f)
-                    .fillMaxSize(),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                StadiumDetailPictureViewPager(
-                    context = context,
-                    pictures = pictures
+    blockReviews.let { uiState ->
+        when (uiState) {
+            is UiState.Empty -> Unit
+            is UiState.Failure -> Unit
+            is UiState.Loading -> Unit
+            is UiState.Success -> {
+                val reviews = uiState.data.reviews
+                val initPage = reviews.indexOfFirst { it.id == reviewId }
+                val pagerState = rememberPagerState(
+                    pageCount = { reviews.size },
+                    initialPage = initPage
                 )
-            }
 
-            Column(
-                modifier = Modifier
-                    .zIndex(if (isDimmed) 3f else 2f)
-                    .fillMaxSize()
-                    .clickable(
-                        enabled = isDimmed,
-                        onClick = {
-                            if (isDimmed) {
-                                isDimmed = false
-                                isMoreButton = true
-                                isMore = false
-                            }
-                        }
-                    )
-                    .background(
-                        color = if (isDimmed) {
-                            Color.Black.copy(alpha = 0.6f)
-                        } else {
-                            Color.Black.copy(alpha = 0.5f)
-                        }
-                    )
-                    .padding(horizontal = 16.dp)
-                    .padding(bottom = 30.dp),
-                verticalArrangement = Arrangement.Bottom
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    AsyncImage(
-                        model = ImageRequest.Builder(context)
-                            .data(reviews[page].profile)
-                            .build(),
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        placeholder = ColorPainter(Color.LightGray),
-                        modifier = Modifier
-                            .size(20.dp)
-                            .clip(CircleShape)
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = reviews[page].user,
-                        fontSize = 12.sp,
-                        color = Color(0xFF9F9F9F)
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    LevelCard(level = reviews[page].level)
+                LaunchedEffect(key1 = pagerState) {
+                    snapshotFlow { pagerState.currentPage }.collect {
+                        isMore = false
+                        isMoreButton = false
+                        isDimmed = false
+                    }
                 }
-                Spacer(modifier = Modifier.height(16.dp))
-                Text(
-                    text = reviews[page].seat,
-                    fontSize = 16.sp,
-                    color = Color.White,
-                    fontWeight = FontWeight.Bold
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Row(
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    Text(
-                        text = reviews[page].content,
-                        fontSize = 14.sp,
-                        maxLines = if (isMore) {
-                            Int.MAX_VALUE
-                        } else {
-                            1
-                        },
-                        overflow = TextOverflow.Ellipsis,
-                        color = Color.White,
-                        onTextLayout = {
-                            if (!isMore) {
-                                if (it.size.width > context.resources.displayMetrics.widthPixels * 0.75) {
-                                    isMoreButton = true
+
+                VerticalPager(
+                    state = pagerState,
+                    modifier = modifier
+                        .fillMaxSize()
+                        .background(Color.White)
+                ) { page ->
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        AsyncImage(
+                            model = ImageRequest.Builder(context)
+                                .data(reviews[page].images.getOrNull(0)?.url)
+                                .build(),
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .zIndex(1f)
+                                .blur(5.dp)
+                        )
+
+                        Column(
+                            modifier = Modifier
+                                .zIndex(if (isDimmed) 2f else 3f)
+                                .fillMaxSize(),
+                            verticalArrangement = Arrangement.Center,
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            StadiumDetailPictureViewPager(
+                                context = context,
+                                pictures = reviews[page].images
+                            )
+                        }
+
+                        Column(
+                            modifier = Modifier
+                                .zIndex(if (isDimmed) 3f else 2f)
+                                .fillMaxSize()
+                                .clickable(
+                                    enabled = isDimmed,
+                                    onClick = {
+                                        if (isDimmed) {
+                                            isDimmed = false
+                                            isMoreButton = true
+                                            isMore = false
+                                        }
+                                    }
+                                )
+                                .background(
+                                    color = if (isDimmed) {
+                                        Color.Black.copy(alpha = 0.6f)
+                                    } else {
+                                        Color.Black.copy(alpha = 0.5f)
+                                    }
+                                )
+                                .padding(horizontal = 16.dp)
+                                .padding(bottom = 30.dp),
+                            verticalArrangement = Arrangement.Bottom
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                AsyncImage(
+                                    model = ImageRequest.Builder(context)
+//                                        .data(reviews[page].profile)
+                                        .build(),
+                                    contentDescription = null,
+                                    contentScale = ContentScale.Crop,
+                                    placeholder = ColorPainter(Color.LightGray),
+                                    modifier = Modifier
+                                        .size(20.dp)
+                                        .clip(CircleShape)
+                                )
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Text(
+//                                    text = reviews[page].user,
+                                    text = "test",
+                                    fontSize = 12.sp,
+                                    color = Color(0xFF9F9F9F)
+                                )
+                                Spacer(modifier = Modifier.width(4.dp))
+                                LevelCard(
+//                                    level = reviews[page].level,
+                                    level = 1
+                                )
+                            }
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Text(
+//                                text = reviews[page].seat,
+                                text = "207블럭 1열 12번",
+                                fontSize = 16.sp,
+                                color = Color.White,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Row(
+                                horizontalArrangement = Arrangement.Center
+                            ) {
+                                Text(
+                                    text = reviews[page].content,
+                                    fontSize = 14.sp,
+                                    maxLines = if (isMore) {
+                                        Int.MAX_VALUE
+                                    } else {
+                                        1
+                                    },
+                                    overflow = TextOverflow.Ellipsis,
+                                    color = Color.White,
+                                    onTextLayout = {
+                                        if (!isMore) {
+                                            if (it.size.width > context.resources.displayMetrics.widthPixels * 0.75) {
+                                                isMoreButton = true
+                                            }
+                                        }
+                                    },
+                                    modifier = Modifier.fillMaxWidth(if (isMoreButton) 0.8f else 1f)
+                                )
+                                if (isMoreButton) {
+                                    Spacer(modifier = Modifier.width(10.dp))
+                                    Text(
+                                        text = "더보기",
+                                        fontSize = 13.sp,
+                                        color = Color.White,
+                                        fontWeight = FontWeight.Bold,
+                                        textDecoration = TextDecoration.Underline,
+                                        modifier = Modifier.clickable {
+                                            isMoreButton = false
+                                            isMore = true
+                                            isDimmed = true
+                                        }
+                                    )
                                 }
                             }
-                        },
-                        modifier = Modifier.fillMaxWidth(if (isMoreButton) 0.8f else 1f)
-                    )
-                    if (isMoreButton) {
-                        Spacer(modifier = Modifier.width(10.dp))
-                        Text(
-                            text = "더보기",
-                            fontSize = 13.sp,
-                            color = Color.White,
-                            fontWeight = FontWeight.Bold,
-                            textDecoration = TextDecoration.Underline,
-                            modifier = Modifier.clickable {
-                                isMoreButton = false
-                                isMore = true
-                                isDimmed = true
-                            }
-                        )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            KeywordFlowRow(
+                                keywords = reviews[page].keywords.map { it.toKeyword() },
+                                overflowIndex = if (isDimmed) {
+                                    Int.MAX_VALUE
+                                } else {
+                                    2
+                                },
+                                isSelfExpanded = false,
+                                onActionCallback = {
+                                    isMoreButton = false
+                                    isMore = true
+                                    isDimmed = true
+                                }
+                            )
+                        }
                     }
                 }
-                Spacer(modifier = Modifier.height(8.dp))
-                KeywordFlowRow(
-                    keywords = reviews[page].keyword,
-                    overflowIndex = if (isDimmed) {
-                        Int.MAX_VALUE
-                    } else {
-                        2
-                    },
-                    isSelfExpanded = false,
-                    onActionCallback = {
-                        isMoreButton = false
-                        isMore = true
-                        isDimmed = true
-                    }
-                )
             }
         }
     }
+
+
 }
 
 @Preview
@@ -229,6 +255,6 @@ fun StadiumDetailPictureScreen(
 private fun StadiumDetailPictureScreenPreview() {
     StadiumDetailPictureScreen(
         context = LocalContext.current,
-        reviews = reviewContents,
+        reviewId = 1,
     )
 }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/detailpicture/StadiumDetailPictureViewPager.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/compose/detailpicture/StadiumDetailPictureViewPager.kt
@@ -33,13 +33,14 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.airbnb.lottie.model.content.CircleShape
+import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
 import com.depromeet.presentation.viewfinder.sample.pictures
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun StadiumDetailPictureViewPager(
     context: Context,
-    pictures: List<String>,
+    pictures: List<BlockReviewResponse.ReviewResponse.ReviewImageResponse>,
     modifier: Modifier = Modifier
 ) {
     val pagerState = rememberPagerState(pageCount = { pictures.size })
@@ -60,7 +61,7 @@ fun StadiumDetailPictureViewPager(
             ) {
                 AsyncImage(
                     model = ImageRequest.Builder(context)
-                        .data(pictures.getOrNull(page))
+                        .data(pictures.getOrNull(page)?.url)
                         .crossfade(true)
                         .build(),
                     contentScale = ContentScale.FillWidth,
@@ -97,6 +98,16 @@ fun StadiumDetailPictureViewPager(
 private fun StadiumDetailPictureViewPagerPreview() {
     StadiumDetailPictureViewPager(
         context = LocalContext.current,
-        pictures = pictures
+        pictures = listOf(
+            BlockReviewResponse.ReviewResponse.ReviewImageResponse(
+                id = 1 , url = ""
+            ),
+            BlockReviewResponse.ReviewResponse.ReviewImageResponse(
+                id = 1 , url = ""
+            ),
+            BlockReviewResponse.ReviewResponse.ReviewImageResponse(
+                id = 1 , url = ""
+            )
+        )
     )
 }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewholder/StadiumSelectionViewHolder.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewholder/StadiumSelectionViewHolder.kt
@@ -1,27 +1,26 @@
 package com.depromeet.presentation.viewfinder.viewholder
 
-import android.util.Log
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.depromeet.designsystem.SpotTeamLabel
+import com.depromeet.domain.entity.response.viewfinder.StadiumsResponse
 import com.depromeet.presentation.databinding.ItemStadiumSelectionBinding
-import com.depromeet.presentation.viewfinder.sample.Stadium
 
 class StadiumSelectionViewHolder(
     private val binding: ItemStadiumSelectionBinding
 ) : RecyclerView.ViewHolder(binding.root) {
-    fun bind(item: Stadium) {
+    fun bind(stadiums: StadiumsResponse) {
         with(binding) {
-            tvStadiumTitle.text = item.title
-            ivStadium.load(item.imageUrl)
-            if (item.lock) {
+            tvStadiumTitle.text = stadiums.name
+            ivStadium.load(stadiums.thumbnail)
+            if (stadiums.isActive) {
                 binding.cvStadiumLock.visibility = View.VISIBLE
             }
-            item.team.forEach { teamName ->
+            stadiums.homeTeams.forEach { teamName ->
                 binding.llStadiumTeamLabel.addView(
                     SpotTeamLabel(binding.root.context).apply {
-                        teamType = teamName
+                        teamType = teamName.alias
                     }
                 )
             }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewmodel/StadiumDetailViewModel.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewmodel/StadiumDetailViewModel.kt
@@ -1,14 +1,24 @@
 package com.depromeet.presentation.viewfinder.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.depromeet.core.state.UiState
+import com.depromeet.domain.entity.response.viewfinder.BlockReviewResponse
+import com.depromeet.domain.repository.ViewfinderRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class StadiumDetailViewModel @Inject constructor() : ViewModel() {
+class StadiumDetailViewModel @Inject constructor(
+    private val viewfinderRepository: ViewfinderRepository
+) : ViewModel() {
+    private val _blockReviews = MutableStateFlow<UiState<BlockReviewResponse>>(UiState.Loading)
+    val blockReviews: StateFlow<UiState<BlockReviewResponse>> = _blockReviews.asStateFlow()
+
     private val _scrollState = MutableStateFlow(false)
     val scrollState = _scrollState.asStateFlow()
 
@@ -21,5 +31,15 @@ class StadiumDetailViewModel @Inject constructor() : ViewModel() {
 
     fun updateMonth(month: Int) {
         _month.value = month
+    }
+
+    fun getBlockReviews(stadiumId: Int, blockId: String) {
+        viewModelScope.launch {
+            viewfinderRepository.getBlockReviews(stadiumId, blockId).onSuccess { blockReviews ->
+                _blockReviews.value = UiState.Success(blockReviews)
+            }.onFailure { e ->
+                _blockReviews.value = UiState.Failure(e.message ?: "실패")
+            }
+        }
     }
 }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewmodel/StadiumSelectionViewModel.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewmodel/StadiumSelectionViewModel.kt
@@ -20,12 +20,10 @@ class StadiumSelectionViewModel @Inject constructor(
 
     fun getStadiums() {
         viewModelScope.launch {
-            _stadiums.value = viewfinderRepository.getStadiums().let { stadiums ->
-                if (stadiums.isEmpty()) {
-                    UiState.Failure("exception")
-                } else {
-                    UiState.Success(stadiums)
-                }
+            viewfinderRepository.getStadiums().onSuccess {
+                _stadiums.value = UiState.Success(it)
+            }.onFailure {
+                _stadiums.value = UiState.Failure(it.message.toString())
             }
         }
     }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewmodel/StadiumSelectionViewModel.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewmodel/StadiumSelectionViewModel.kt
@@ -1,0 +1,32 @@
+package com.depromeet.presentation.viewfinder.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.depromeet.core.state.UiState
+import com.depromeet.domain.entity.response.viewfinder.StadiumsResponse
+import com.depromeet.domain.repository.ViewfinderRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class StadiumSelectionViewModel @Inject constructor(
+    private val viewfinderRepository: ViewfinderRepository
+) : ViewModel() {
+    private val _stadiums = MutableStateFlow<UiState<List<StadiumsResponse>>>(UiState.Loading)
+    val stadiums = _stadiums.asStateFlow()
+
+    fun getStadiums() {
+        viewModelScope.launch {
+            _stadiums.value = viewfinderRepository.getStadiums().let { stadiums ->
+                if (stadiums.isEmpty()) {
+                    UiState.Failure("exception")
+                } else {
+                    UiState.Success(stadiums)
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewmodel/StadiumViewModel.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewmodel/StadiumViewModel.kt
@@ -29,9 +29,11 @@ class StadiumViewModel @Inject constructor(
     fun downloadFileFromServer(url: String) {
         viewModelScope.launch {
             webSvgRepository.downloadFileWithDynamicUrlAsync(url).let { svgString ->
-                _htmlBody.value = if (svgString.isEmpty()) UiState.Failure("") else UiState.Success(
-                    getHTMLBody(svgString)
-                )
+                svgString.onSuccess {
+                    _htmlBody.value = UiState.Success(it)
+                }.onFailure {
+                    _htmlBody.value = UiState.Failure(it.message.toString())
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewmodel/StadiumViewModel.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewmodel/StadiumViewModel.kt
@@ -3,6 +3,8 @@ package com.depromeet.presentation.viewfinder.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.depromeet.core.state.UiState
+import com.depromeet.domain.entity.response.viewfinder.StadiumResponse
+import com.depromeet.domain.repository.ViewfinderRepository
 import com.depromeet.domain.repository.WebSvgRepository
 import com.depromeet.presentation.util.getHTMLBody
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,10 +15,14 @@ import javax.inject.Inject
 
 @HiltViewModel
 class StadiumViewModel @Inject constructor(
-    private val webSvgRepository: WebSvgRepository
+    private val webSvgRepository: WebSvgRepository,
+    private val viewfinderRepository: ViewfinderRepository
 ) : ViewModel() {
     private val _htmlBody = MutableStateFlow<UiState<String>>(UiState.Loading)
     val htmlBody = _htmlBody.asStateFlow()
+
+    private val _stadium = MutableStateFlow<UiState<StadiumResponse>>(UiState.Loading)
+    val stadium = _stadium.asStateFlow()
 
     fun downloadFileFromServer(url: String) {
         viewModelScope.launch {
@@ -24,6 +30,16 @@ class StadiumViewModel @Inject constructor(
                 _htmlBody.value = if (svgString.isEmpty()) UiState.Failure("") else UiState.Success(
                     getHTMLBody(svgString)
                 )
+            }
+        }
+    }
+
+    fun getStadium(id: Int) {
+        viewModelScope.launch {
+            viewfinderRepository.getStadium(id).onSuccess { stadium ->
+                _stadium.value = UiState.Success(stadium)
+            }.onFailure { e ->
+                _stadium.value = UiState.Failure(e.message ?: "")
             }
         }
     }

--- a/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewmodel/StadiumViewModel.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/viewfinder/viewmodel/StadiumViewModel.kt
@@ -18,6 +18,8 @@ class StadiumViewModel @Inject constructor(
     private val webSvgRepository: WebSvgRepository,
     private val viewfinderRepository: ViewfinderRepository
 ) : ViewModel() {
+    var stadiumId: Int = 0
+
     private val _htmlBody = MutableStateFlow<UiState<String>>(UiState.Loading)
     val htmlBody = _htmlBody.asStateFlow()
 


### PR DESCRIPTION
- closed #28 

## **💻주요 작업 내용**
- 야구장 불러오기
- 야구장 svg url 불러오기
- 블록 별 리뷰 데이터바인딩
- 리뷰 별 사진 디테일 데이터바인딩

## **🎞리뷰 요청 사항**
- 서버쪽에서 명세한 데이터 response 로 바인딩해서 아직 부족한 점이 많은데, 일단 노션 api 명세서에 요청해놨씁니다!!
- 부족한 부분은 이슈만들어서 다시 작업하겠습니다

## 부족한 부분
- 블록 별 리뷰 및 리뷰 디테일 데이터 바인딩 (유저, 상단 뷰페이저 이미지, "207블럭 오렌지석" 텍스트...)
- 월별 필터링
- 좌석 선택 api 연동 및 필터링
- 신고하기 구글폼 링크 연동

## 시연영상

https://github.com/user-attachments/assets/034e420a-b7fe-4a90-beda-d6bbec70fdb8
