### PR TITLE
[FEAT] 카카오 공유하기 예시 템플릿 작성

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,10 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
+    <queries>
+        <package android:name="com.kakao.talk" />
+    </queries>
+
     <application
         android:name="com.depromeet.spot.MyApp"
         android:allowBackup="true"
@@ -24,6 +28,23 @@
         android:theme="@style/Theme.DepromeetAndroid"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+        <activity
+            android:name="com.depromeet.presentation.scheme.SchemeActivity"
+            android:exported="true"
+            android:launchMode="singleTop">
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:host="kakaolink"
+                    android:scheme="kakao${kakaoApiKey}" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name="com.depromeet.presentation.ExampleActivity"
+            android:exported="false">
+        </activity>
         <activity
             android:name="com.depromeet.presentation.MainActivity"
             android:exported="false"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -77,6 +77,7 @@ object ThirdPartyDependencies {
     const val lottie = "com.airbnb.android:lottie:${Versions.lottieVersion}"
     const val lottieCompose = "com.airbnb.android:lottie-compose:${Versions.lottieVersion}"
     const val kakaoLogin = "com.kakao.sdk:v2-user:${Versions.kakaoVersion}"
+    const val kakaoShare = "com.kakao.sdk:v2-share:${Versions.kakaoVersion}"
     const val indicator = "me.relex:circleindicator:${Versions.circleIndicator}"
     const val shimmer = "com.facebook.shimmer:shimmer:${Versions.shimmerVersion}"
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
         implementation(balloon)
         implementation(lottie)
         implementation(kakaoLogin)
+        implementation(kakaoShare)
         implementation(indicator)
         implementation(shimmer)
         debugImplementation(flipperLeakCanary)

--- a/presentation/src/main/java/com/depromeet/presentation/ExampleActivity.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/ExampleActivity.kt
@@ -15,7 +15,7 @@ class ExampleActivity : BaseActivity<ActivityExampleBinding>(ActivityExampleBind
          * @sample : 카카오 공유하기
          * @author : 조관희
          */
-        binding.btnKakaShare.setOnClickListener {
+        binding.btnKakaoShare.setOnClickListener {
             KakaoUtils().share(
                 this,
                 template = mockDefaultFeed,

--- a/presentation/src/main/java/com/depromeet/presentation/ExampleActivity.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/ExampleActivity.kt
@@ -1,0 +1,31 @@
+package com.depromeet.presentation
+
+import android.os.Bundle
+import com.depromeet.core.base.BaseActivity
+import com.depromeet.presentation.databinding.ActivityExampleBinding
+import com.depromeet.presentation.extension.toast
+import com.depromeet.presentation.util.KakaoUtils
+import com.depromeet.presentation.util.mockDefaultFeed
+
+class ExampleActivity : BaseActivity<ActivityExampleBinding>(ActivityExampleBinding::inflate) {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        /**
+         * @sample : 카카오 공유하기
+         * @author : 조관희
+         */
+        binding.btnKakaShare.setOnClickListener {
+            KakaoUtils().share(
+                this,
+                template = mockDefaultFeed,
+                onSuccess = { sharingIntent ->
+                    startActivity(sharingIntent)
+                },
+                onFailure = { throwable ->
+                    toast(throwable.message ?: "failed")
+                }
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/depromeet/presentation/scheme/SchemeActivity.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/scheme/SchemeActivity.kt
@@ -1,0 +1,68 @@
+package com.depromeet.presentation.scheme
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import com.depromeet.core.base.BaseActivity
+import com.depromeet.presentation.databinding.ActivitySchemeBinding
+import com.depromeet.presentation.extension.toast
+
+class SchemeActivity : BaseActivity<ActivitySchemeBinding>(ActivitySchemeBinding::inflate) {
+
+    companion object {
+        /**
+         * 딥링크 URL 파라미터인 KEY 상수 정의
+         * kakaolink://[kakao_native_key]?[key1]=[value1]&[key2]=[value2]]
+         * Link(
+         *     androidExecutionParams = mapOf("section" to "오렌지석", "block" to "102")
+         * )
+         *
+         * val section = handleQueryParameter(appLinkData, "section") // 오렌지석
+         * val block = handleQueryParameter(appLinkData, "block") // 102
+         */
+        const val EXAMPLE_KEY = "example_key"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        handleIntent(intent)
+    }
+
+    @SuppressLint("MissingSuperCall")
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleIntent(intent)
+    }
+
+    private fun handleIntent(intent: Intent) {
+        val appLinkAction = intent.action
+        val appLinkData: Uri? = intent.data
+        if (Intent.ACTION_VIEW == appLinkAction) {
+            handleQueryParameter(appLinkData, EXAMPLE_KEY)
+            // handlePathParameter(appLinkData)
+        }
+    }
+
+    private fun handleQueryParameter(
+        uri: Uri?,
+        key: String
+    ): String? {
+        return uri?.getQueryParameter(key)
+    }
+
+
+    private fun handlePathParameter(
+        uri: Uri?
+    ) {
+        uri?.lastPathSegment?.also { pathParameter ->
+            Uri.parse("content://com.depromeet.spot/")
+                .buildUpon()
+                .appendPath(pathParameter)
+                .build().also { appData ->
+                    toast(appData.toString())
+                }
+        }
+    }
+}

--- a/presentation/src/main/java/com/depromeet/presentation/util/KakaoUtils.kt
+++ b/presentation/src/main/java/com/depromeet/presentation/util/KakaoUtils.kt
@@ -1,0 +1,71 @@
+package com.depromeet.presentation.util
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import com.kakao.sdk.common.util.KakaoCustomTabsClient
+import com.kakao.sdk.share.ShareClient
+import com.kakao.sdk.share.WebSharerClient
+import com.kakao.sdk.template.model.Button
+import com.kakao.sdk.template.model.Content
+import com.kakao.sdk.template.model.DefaultTemplate
+import com.kakao.sdk.template.model.FeedTemplate
+import com.kakao.sdk.template.model.Link
+
+val mockDefaultFeed = FeedTemplate(
+    content = Content(
+        title = "오늘의 디저트",
+        description = "#케익 #딸기 #삼평동 #카페 #분위기 #소개팅",
+        imageUrl = "https://mud-kage.kakao.com/dn/Q2iNx/btqgeRgV54P/VLdBs9cvyn8BJXB3o7N8UK/kakaolink40_original.png",
+        link = Link(
+            webUrl = "https://play.google.com",
+            mobileWebUrl = "https://play.google.com"
+        )
+    ),
+    buttons = listOf(
+        Button(
+            "앱으로 보기",
+            Link(
+                androidExecutionParams = mapOf("key1" to "value1", "key2" to "value2")
+            )
+        )
+    )
+)
+
+class KakaoUtils() {
+    fun share(
+        context: Context,
+        template: DefaultTemplate,
+        onSuccess: (intent: Intent) -> Unit = {},
+        onFailure: (Throwable) -> Unit = {}
+    ) {
+        if (ShareClient.instance.isKakaoTalkSharingAvailable(context)) {
+            // 카카오톡으로 카카오톡 공유 가능
+            ShareClient.instance.shareDefault(context, template) { sharingResult, error ->
+                if (error != null) {
+                    onFailure(error)
+                } else if (sharingResult != null) {
+                    onSuccess(sharingResult.intent)
+                }
+            }
+        } else { // 카카오톡 미설치: 웹 공유 사용 권장
+            val sharerUrl = WebSharerClient.instance.makeDefaultUrl(template)
+
+            // 1. CustomTabsServiceConnection 지원 브라우저 열기
+            // ex) Chrome, 삼성 인터넷, FireFox, 웨일 등
+            try {
+                KakaoCustomTabsClient.openWithDefault(context, sharerUrl)
+            } catch (e: UnsupportedOperationException) {
+                // CustomTabsServiceConnection 지원 브라우저가 없을 때 예외처리
+            }
+
+            // 2. CustomTabsServiceConnection 미지원 브라우저 열기
+            // ex) 다음, 네이버 등
+            try {
+                KakaoCustomTabsClient.open(context, sharerUrl)
+            } catch (e: ActivityNotFoundException) {
+                // 디바이스에 설치된 인터넷 브라우저가 없을 때 예외처리
+            }
+        }
+    }
+}

--- a/presentation/src/main/res/layout/activity_example.xml
+++ b/presentation/src/main/res/layout/activity_example.xml
@@ -5,7 +5,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <Button
-        android:id="@+id/btn_kaka_share"
+        android:id="@+id/btnKakaoShare"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="카카오 공유하기"

--- a/presentation/src/main/res/layout/activity_example.xml
+++ b/presentation/src/main/res/layout/activity_example.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <Button
+        android:id="@+id/btn_kaka_share"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="카카오 공유하기"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/activity_scheme.xml
+++ b/presentation/src/main/res/layout/activity_scheme.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- closed #95 

## **💻주요 작업 내용**
- 투명 액티비티 (SchemeActivity) 생성
  - 모든 스킴처리를 해당 액티비티로 하기 위함
- 카카오 공유하기 유틸 클래스로 구현
- ExampleActivity 생성
  - 카카오 공유하기 등 기능에 대한 예시 액티비티를 만들어 보았어요!

## **🎞리뷰 요청 사항**
- 딥 링크를 처리해보지 않았지만 투명 액티비티로 스킴 처리를 하려고 했습니다! 
- 엣지 케이스)
  - 앱이 깔려있지 않을 때 : Kakao Delveoper 에 가서 안드로이드 플랫폼의 마켓 URL 로 리다이렉트 되는 구조인 것 같아요! 만약에 앱이 배포되면 앱 배포 링크를 등록하면 될 것 같습니다!
  -  아이폰 유저는? : 아이폰 유저는 앱이 깔려있지 않은 전제하에 작동하기 때문에 구글 플레이스토어 앱이 아닌 구글 플레이 스토어 웹(Safari) 로 이동하더군요..

## 시연 영상
https://github.com/user-attachments/assets/d8aead8e-d76d-4877-b9a6-f41cf86dbcfa

## 구조
<img width="1423" alt="image" src="https://github.com/user-attachments/assets/025847f9-d7da-4199-a769-8c3a8f32a364">


## 레퍼런스
- [카카오 디밸로퍼 공유하기 문서](https://developers.kakao.com/docs/latest/ko/message/common)
- [투명 액티비티 딥링크 핸들링 문서](https://medium.com/%EB%B0%95%EC%83%81%EA%B6%8C%EC%9D%98-%EC%82%BD%EC%A7%88%EB%B8%94%EB%A1%9C%EA%B7%B8/%EB%94%A5%EB%A7%81%ED%81%AC-deeplink-%EC%B2%98%EB%A6%AC-schemeactivity-%ED%95%98%EB%82%98%EB%A1%9C-%EB%81%9D%EB%82%B4%EA%B8%B0-877c2b60619b)
- [안드로이드 공식 문서 - 앱링크](https://developer.android.com/training/app-links?hl=ko)
- [안드로이드 공식 문서 - 앱링크 테스트](https://developer.android.com/studio/write/app-link-indexing?hl=ko)