### PR TITLE
[BSVR-223/FEAT] 시야 후기 등록 TAB 이동 및 SnackBar 추가

### DIFF
--- a/core/src/main/java/com/dpm/core/base/BindingBottomSheetDialog.kt
+++ b/core/src/main/java/com/dpm/core/base/BindingBottomSheetDialog.kt
@@ -13,7 +13,7 @@ abstract class BindingBottomSheetDialog<B : ViewBinding>(
     private val bindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> B,
 ) : BottomSheetDialogFragment() {
 
-    var _binding: B? = null
+    private var _binding: B? = null
     protected val binding: B
         get() = requireNotNull(_binding) { "binding object is not initialized" }
 

--- a/core/src/main/java/com/dpm/core/base/BindingBottomSheetDialog.kt
+++ b/core/src/main/java/com/dpm/core/base/BindingBottomSheetDialog.kt
@@ -13,7 +13,7 @@ abstract class BindingBottomSheetDialog<B : ViewBinding>(
     private val bindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> B,
 ) : BottomSheetDialogFragment() {
 
-    private var _binding: B? = null
+    var _binding: B? = null
     protected val binding: B
         get() = requireNotNull(_binding) { "binding object is not initialized" }
 

--- a/data/src/main/java/com/dpm/data/datasource/SeatReviewDataSource.kt
+++ b/data/src/main/java/com/dpm/data/datasource/SeatReviewDataSource.kt
@@ -35,7 +35,6 @@ interface SeatReviewDataSource {
 
     suspend fun postSeatReviewData(
         blockId: Int,
-        seatNumber: Int,
         requestSeatReviewDto: RequestSeatReviewDto,
     )
 }

--- a/data/src/main/java/com/dpm/data/datasource/remote/SeatReviewDataSourceImpl.kt
+++ b/data/src/main/java/com/dpm/data/datasource/remote/SeatReviewDataSourceImpl.kt
@@ -58,12 +58,10 @@ class SeatReviewDataSourceImpl @Inject constructor(
 
     override suspend fun postSeatReviewData(
         blockId: Int,
-        seatNumber: Int,
         requestSeatReviewDto: RequestSeatReviewDto,
     ) {
         return seatReviewService.postSeatReview(
             blockId,
-            seatNumber,
             requestSeatReviewDto,
         )
     }

--- a/data/src/main/java/com/dpm/data/model/request/seatreview/RequestSeatReviewDto.kt
+++ b/data/src/main/java/com/dpm/data/model/request/seatreview/RequestSeatReviewDto.kt
@@ -6,22 +6,28 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class RequestSeatReviewDto(
+    @SerialName("rowNumber")
+    val rowNumber: Int?,
+    @SerialName("seatNumber")
+    val seatNumber: Int?,
     @SerialName("images")
     val images: List<String>,
-    @SerialName("dateTime")
-    val dateTime: String,
     @SerialName("good")
     val good: List<String>,
     @SerialName("bad")
     val bad: List<String>,
     @SerialName("content")
     val content: String?,
+    @SerialName("dateTime")
+    val dateTime: String,
 )
 
 fun RequestSeatReview.toSeatReview() = RequestSeatReviewDto(
+    rowNumber = rowNumber,
+    seatNumber = seatNumber,
     images = images,
-    dateTime = dateTime,
     good = good,
     bad = bad,
     content = content,
+    dateTime = dateTime,
 )

--- a/data/src/main/java/com/dpm/data/remote/SeatReviewService.kt
+++ b/data/src/main/java/com/dpm/data/remote/SeatReviewService.kt
@@ -47,10 +47,9 @@ interface SeatReviewService {
         @Body image: RequestBody,
     )
 
-    @POST("/api/v1/blocks/{blockId}/seats/{seatNumber}/reviews")
+    @POST("/api/v1/blocks/{blockId}/reviews")
     suspend fun postSeatReview(
         @Path("blockId") blockId: Int,
-        @Path("seatNumber") seatNumber: Int,
         @Body requestPostSignupDto: RequestSeatReviewDto,
     )
 }

--- a/data/src/main/java/com/dpm/data/repository/SeatReviewRepositoryImpl.kt
+++ b/data/src/main/java/com/dpm/data/repository/SeatReviewRepositoryImpl.kt
@@ -76,13 +76,11 @@ class SeatReviewRepositoryImpl @Inject constructor(
 
     override suspend fun postSeatReview(
         blockId: Int,
-        seatNumber: Int,
         seatReviewInfo: RequestSeatReview,
     ): Result<Unit> {
         return runCatching {
             seatReviewDataSource.postSeatReviewData(
                 blockId,
-                seatNumber,
                 seatReviewInfo.toSeatReview(),
             )
         }

--- a/domain/src/main/java/com/dpm/domain/entity/request/seatreview/RequestSeatReview.kt
+++ b/domain/src/main/java/com/dpm/domain/entity/request/seatreview/RequestSeatReview.kt
@@ -1,9 +1,11 @@
 package com.dpm.domain.entity.request.seatreview
 
 data class RequestSeatReview(
+    val rowNumber: Int?,
+    val seatNumber: Int?,
     val images: List<String>,
-    val dateTime: String,
     val good: List<String>,
     val bad: List<String>,
     val content: String?,
+    val dateTime: String,
 )

--- a/domain/src/main/java/com/dpm/domain/repository/SeatReviewRepository.kt
+++ b/domain/src/main/java/com/dpm/domain/repository/SeatReviewRepository.kt
@@ -34,8 +34,7 @@ interface SeatReviewRepository {
     ): Result<Unit>
 
     suspend fun postSeatReview(
-        seatId: Int,
-        seatNumber: Int,
+        blockId: Int,
         seatReviewInfo: RequestSeatReview,
     ): Result<Unit>
 }

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/ReviewActivity.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/ReviewActivity.kt
@@ -369,11 +369,11 @@ class ReviewActivity : BaseActivity<ActivityReviewBinding>({
             when {
                 !(isSelectedGoodBtnFilled || isSelectedBadBtnFilled) && (isSelectedBlockFilled || (isSelectedColumnFilled || isSelectedNumberFilled)) -> {
                     binding.tvUploadBtn.setBackgroundResource(R.drawable.rect_action_disabled_fill_8)
-                    makeSpotImageAppbar("내 시야 후기를 등록해주세요", 67)
+                    makeSpotImageAppbar("내 시야 후기를 등록해주세요")
                 }
                 !(isSelectedBlockFilled && (isSelectedColumnFilled || isSelectedNumberFilled)) && (isSelectedGoodBtnFilled || isSelectedBadBtnFilled) -> {
                     binding.tvUploadBtn.setBackgroundResource(R.drawable.rect_action_disabled_fill_8)
-                    makeSpotImageAppbar("좌석을 선택해주세요", 88)
+                    makeSpotImageAppbar("좌석을 선택해주세요")
                 }
                 ((!isSelectedGoodBtnFilled && !isSelectedBadBtnFilled) || !(isSelectedBlockFilled && (isSelectedColumnFilled || isSelectedNumberFilled))) -> {
                     binding.tvUploadBtn.setBackgroundResource(R.drawable.rect_action_disabled_fill_8)
@@ -446,14 +446,14 @@ class ReviewActivity : BaseActivity<ActivityReviewBinding>({
         }
     }
 
-    private fun makeSpotImageAppbar(message: String, marginHorizontal: Int) {
+    private fun makeSpotImageAppbar(message: String) {
         SpotImageSnackBar.make(
             view = binding.root,
             message = message,
             messageColor = com.depromeet.designsystem.R.color.color_foreground_white,
             icon = com.depromeet.designsystem.R.drawable.ic_alert_circle,
             iconColor = com.depromeet.designsystem.R.color.color_error_secondary,
-            marginHorizontal = marginHorizontal,
+            marginBottom = 96,
         ).show()
     }
 }

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/ReviewActivity.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/ReviewActivity.kt
@@ -19,6 +19,7 @@ import com.depromeet.presentation.R
 import com.depromeet.presentation.databinding.ActivityReviewBinding
 import com.dpm.core.base.BaseActivity
 import com.dpm.core.state.UiState
+import com.dpm.designsystem.SpotImageSnackBar
 import com.dpm.presentation.extension.setOnSingleClickListener
 import com.dpm.presentation.extension.toast
 import com.dpm.presentation.home.HomeActivity
@@ -326,11 +327,12 @@ class ReviewActivity : BaseActivity<ActivityReviewBinding>({
         val isSelectedNumberFilled = viewModel.selectedNumber.value.isNotEmpty()
 
         with(binding.tvUploadBtn) {
-            isEnabled = isSelectedDateFilled && isSelectedImageFilled &&
+            val isReadyToUpload = isSelectedDateFilled && isSelectedImageFilled &&
                 (isSelectedGoodBtnFilled || isSelectedBadBtnFilled) &&
                 isSelectedBlockFilled &&
                 (isSelectedColumnFilled || isSelectedNumberFilled)
-            if (isEnabled) {
+
+            if (isReadyToUpload) {
                 setBackgroundResource(R.drawable.rect_action_enabled_fill_8)
             } else {
                 setBackgroundResource(R.drawable.rect_action_disabled_fill_8)
@@ -359,15 +361,35 @@ class ReviewActivity : BaseActivity<ActivityReviewBinding>({
 
     private fun initEventUploadBtn() {
         binding.tvUploadBtn.setOnSingleClickListener {
-            val uniqueImageUris = selectedImageUris.distinct()
-            uniqueImageUris.forEach { imageUriString ->
-                val imageUri = Uri.parse(imageUriString)
-                val fileExtension = getFileExtension(this, imageUri)
-                val imageData = readImageData(this, imageUri)
-                if (imageData != null) {
-                    viewModel.requestPreSignedUrl(fileExtension)
-                } else {
-                    toast("파일을 읽을 수 없습니다.")
+            val isSelectedGoodBtnFilled = viewModel.selectedGoodReview.value.isNotEmpty()
+            val isSelectedBadBtnFilled = viewModel.selectedBadReview.value.isNotEmpty()
+            val isSelectedBlockFilled = viewModel.selectedBlock.value.isNotEmpty()
+            val isSelectedColumnFilled = viewModel.selectedColumn.value.isNotEmpty()
+            val isSelectedNumberFilled = viewModel.selectedNumber.value.isNotEmpty()
+            when {
+                !(isSelectedGoodBtnFilled || isSelectedBadBtnFilled) && (isSelectedBlockFilled || (isSelectedColumnFilled || isSelectedNumberFilled)) -> {
+                    binding.tvUploadBtn.setBackgroundResource(R.drawable.rect_action_disabled_fill_8)
+                    makeSpotImageAppbar("내 시야 후기를 등록해주세요", 67)
+                }
+                !(isSelectedBlockFilled && (isSelectedColumnFilled || isSelectedNumberFilled)) && (isSelectedGoodBtnFilled || isSelectedBadBtnFilled) -> {
+                    binding.tvUploadBtn.setBackgroundResource(R.drawable.rect_action_disabled_fill_8)
+                    makeSpotImageAppbar("좌석을 선택해주세요", 88)
+                }
+                ((!isSelectedGoodBtnFilled && !isSelectedBadBtnFilled) || !(isSelectedBlockFilled && (isSelectedColumnFilled || isSelectedNumberFilled))) -> {
+                    binding.tvUploadBtn.setBackgroundResource(R.drawable.rect_action_disabled_fill_8)
+                }
+                else -> {
+                    val uniqueImageUris = selectedImageUris.distinct()
+                    uniqueImageUris.forEach { imageUriString ->
+                        val imageUri = Uri.parse(imageUriString)
+                        val fileExtension = getFileExtension(this, imageUri)
+                        val imageData = readImageData(this, imageUri)
+                        if (imageData != null) {
+                            viewModel.requestPreSignedUrl(fileExtension)
+                        } else {
+                            toast("파일을 읽을 수 없습니다.")
+                        }
+                    }
                 }
             }
         }
@@ -418,8 +440,20 @@ class ReviewActivity : BaseActivity<ActivityReviewBinding>({
                 is UiState.Failure -> {
                     toast("리뷰 등록 실패: $state")
                 }
+
                 else -> {}
             }
         }
+    }
+
+    private fun makeSpotImageAppbar(message: String, marginHorizontal: Int) {
+        SpotImageSnackBar.make(
+            view = binding.root,
+            message = message,
+            messageColor = com.depromeet.designsystem.R.color.color_foreground_white,
+            icon = com.depromeet.designsystem.R.drawable.ic_alert_circle,
+            iconColor = com.depromeet.designsystem.R.color.color_error_secondary,
+            marginHorizontal = marginHorizontal,
+        ).show()
     }
 }

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/ReviewActivity.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/ReviewActivity.kt
@@ -157,8 +157,21 @@ class ReviewActivity : BaseActivity<ActivityReviewBinding>({
 
                     8 -> {
                         tvSeatColor.visibility = GONE
-                        tvSeatBlock.text = block
+                        tvSeatBlock.text = viewModel.getBlockListName(block)
                         tvBlock.visibility = GONE
+                        tvColumnNumber.visibility = VISIBLE
+                        tvColumnNumber.text = column
+                        tvColumn.visibility = VISIBLE
+                        tvSeatNumber.text = number
+                        tvSeatNumber.visibility = VISIBLE
+                        tvNumber.visibility = VISIBLE
+                    }
+
+                    1 -> {
+                        tvSeatColor.visibility = VISIBLE
+                        tvSeatColor.text = seatZone
+                        tvSeatBlock.text = viewModel.getBlockListName(block)
+                        tvBlock.visibility = VISIBLE
                         tvColumnNumber.visibility = VISIBLE
                         tvColumnNumber.text = column
                         tvColumn.visibility = VISIBLE

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/ReviewViewModel.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/ReviewViewModel.kt
@@ -182,6 +182,20 @@ class ReviewViewModel @Inject constructor(
                     else -> codeWithoutW
                 }
             }
+            selectedSectionId.value == 8 && blockCode.startsWith("exciting") -> {
+                when (blockCode) {
+                    "exciting1" -> "1루 익사이팅석"
+                    "exciting3" -> "3루 익사이팅석"
+                    else -> blockCode
+                }
+            }
+
+            selectedSectionId.value == 1 && blockCode.startsWith("premium") -> {
+                when (blockCode) {
+                    "premium" -> "프리미엄석"
+                    else -> blockCode
+                }
+            }
             else -> blockCode
         }
     }

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/ReviewViewModel.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/ReviewViewModel.kt
@@ -1,7 +1,6 @@
 package com.dpm.presentation.seatreview
 
 import android.net.Uri
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -73,6 +72,13 @@ class ReviewViewModel @Inject constructor(
     val selectedNumber: StateFlow<String> = _selectedNumber.asStateFlow()
 
     val userSeatState = MutableLiveData<ValidSeat>()
+
+    private val _sectionItemSelected = MutableStateFlow(false)
+    val sectionItemSelected: StateFlow<Boolean> = _sectionItemSelected
+
+    fun updateItemSelected(isSelected: Boolean) {
+        _sectionItemSelected.value = isSelected
+    }
 
     // 서버 통신
 

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/ReviewViewModel.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/ReviewViewModel.kt
@@ -362,14 +362,6 @@ class ReviewViewModel @Inject constructor(
                 }
                 .onFailure { t ->
                     if (t is HttpException) {
-                        val errorCode = t.code() // HTTP 상태 코드 (403)
-                        val errorBody = t.response()?.errorBody()?.string() // 응답 본문
-                        val errorHeaders = t.response()?.headers()?.toString() // 응답 헤더
-
-                        Timber.e("POST REVIEW FAILURE: HTTP $errorCode")
-                        Timber.e("Error Body: $errorBody")
-                        Timber.e("Error Headers: $errorHeaders")
-                    } else {
                         Timber.e("POST REVIEW FAILURE: $t")
                     }
                 }

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/ReviewMySeatDialog.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/ReviewMySeatDialog.kt
@@ -3,6 +3,7 @@ package com.dpm.presentation.seatreview.dialog
 import android.os.Bundle
 import android.text.Editable
 import android.text.InputFilter
+import android.util.Log
 import android.view.View
 import android.view.View.FOCUS_DOWN
 import android.view.View.FOCUS_UP
@@ -16,6 +17,7 @@ import androidx.lifecycle.asLiveData
 import com.depromeet.presentation.R
 import com.depromeet.presentation.databinding.FragmentReviewMySeatBottomSheetBinding
 import com.dpm.core.base.BindingBottomSheetDialog
+import com.dpm.designsystem.SpotImageSnackBar
 import com.dpm.presentation.extension.colorOf
 import com.dpm.presentation.extension.setOnSingleClickListener
 import com.dpm.presentation.seatreview.ReviewViewModel
@@ -106,6 +108,8 @@ class ReviewMySeatDialog : BindingBottomSheetDialog<FragmentReviewMySeatBottomSh
                     val totalSelectedCount = selectedGoodButtonText.size + selectedBadButtonText.size
                     viewModel.setReviewCount(totalSelectedCount)
                     viewModel.setSelectedGoodReview(selectedGoodButtonText)
+                } else {
+                    makeSpotImageAppbar("후기 키워드는 각각 3개까지 선택할 수 있어요")
                 }
             }
         }
@@ -122,6 +126,8 @@ class ReviewMySeatDialog : BindingBottomSheetDialog<FragmentReviewMySeatBottomSh
                     val totalSelectedCount = selectedGoodButtonText.size + selectedBadButtonText.size
                     viewModel.setReviewCount(totalSelectedCount)
                     viewModel.setSelectedBadReview(selectedBadButtonText)
+                } else {
+                    makeSpotImageAppbar("후기 키워드는 각각 3개까지 선택할 수 있어요")
                 }
             }
         }
@@ -193,6 +199,21 @@ class ReviewMySeatDialog : BindingBottomSheetDialog<FragmentReviewMySeatBottomSh
         with(binding.tvCompleteBtn) {
             isEnabled = enable
             setBackgroundResource(if (isEnabled) R.drawable.rect_action_enabled_fill_8 else R.drawable.rect_action_disabled_fill_8)
+        }
+    }
+
+    private fun makeSpotImageAppbar(message: String) {
+        val parentView = requireDialog().window?.decorView?.findViewById<View>(android.R.id.content)
+        parentView?.let {
+            SpotImageSnackBar.make(
+                it,
+                message = message,
+                messageColor = com.depromeet.designsystem.R.color.color_foreground_white,
+                icon = com.depromeet.designsystem.R.drawable.ic_alert_circle,
+                iconColor = com.depromeet.designsystem.R.color.color_error_secondary,
+                marginBottom = 96,
+                marginHorizontal = 26,
+            ).show()
         }
     }
 }

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/ReviewMySeatDialog.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/ReviewMySeatDialog.kt
@@ -13,9 +13,9 @@ import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.asLiveData
-import com.dpm.core.base.BindingBottomSheetDialog
 import com.depromeet.presentation.R
 import com.depromeet.presentation.databinding.FragmentReviewMySeatBottomSheetBinding
+import com.dpm.core.base.BindingBottomSheetDialog
 import com.dpm.presentation.extension.colorOf
 import com.dpm.presentation.extension.setOnSingleClickListener
 import com.dpm.presentation.seatreview.ReviewViewModel
@@ -46,6 +46,7 @@ class ReviewMySeatDialog : BindingBottomSheetDialog<FragmentReviewMySeatBottomSh
             binding.tvBadFour,
             binding.tvBadFive,
             binding.tvBadSix,
+            binding.tvBadSeven,
         )
     }
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/ReviewMySeatDialog.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/ReviewMySeatDialog.kt
@@ -3,7 +3,6 @@ package com.dpm.presentation.seatreview.dialog
 import android.os.Bundle
 import android.text.Editable
 import android.text.InputFilter
-import android.util.Log
 import android.view.View
 import android.view.View.FOCUS_DOWN
 import android.view.View.FOCUS_UP
@@ -212,7 +211,6 @@ class ReviewMySeatDialog : BindingBottomSheetDialog<FragmentReviewMySeatBottomSh
                 icon = com.depromeet.designsystem.R.drawable.ic_alert_circle,
                 iconColor = com.depromeet.designsystem.R.color.color_error_secondary,
                 marginBottom = 96,
-                marginHorizontal = 26,
             ).show()
         }
     }

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/ReviewMySeatDialog.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/ReviewMySeatDialog.kt
@@ -203,7 +203,7 @@ class ReviewMySeatDialog : BindingBottomSheetDialog<FragmentReviewMySeatBottomSh
     }
 
     private fun makeSpotImageAppbar(message: String) {
-        val parentView = requireDialog().window?.decorView?.findViewById<View>(android.R.id.content)
+        val parentView = binding.root.rootView
         parentView?.let {
             SpotImageSnackBar.make(
                 it,

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
@@ -65,6 +65,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
         adapter = SelectSeatAdapter { position, sectionId ->
             val selectedSeatInfo = adapter.currentList[position]
             adapter.setItemSelected(position)
+            viewModel.updateItemSelected(true)
             viewModel.setSelectedSeatZone(selectedSeatInfo.name)
             viewModel.getSeatBlock(viewModel.selectedStadiumId.value, sectionId)
             viewModel.updateSelectedSectionId(sectionId)
@@ -95,16 +96,72 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
 
     private fun onClickTabVisibility() {
         with(binding) {
-            llTabSelectSection.setOnSingleClickListener {
-                svSelectSeat.visibility = VISIBLE
-                clSeatBlock.visibility = INVISIBLE
-                svSeatNumber.visibility = INVISIBLE
-                tvSelectSeatLine.visibility = VISIBLE
-                tvSelectNumberLine.visibility = INVISIBLE
-                tvCompleteBtn.visibility = INVISIBLE
-                tvNextBtn.visibility = VISIBLE
-                tvSelectZone.setTextColor(binding.root.context.colorOf(com.depromeet.designsystem.R.color.color_foreground_heading))
-                tvSelectNumber.setTextColor(binding.root.context.colorOf(com.depromeet.designsystem.R.color.color_foreground_caption))
+            binding.llTabSelectSeat.setOnSingleClickListener {
+                if (!viewModel.sectionItemSelected.value) {
+                    // TODO : 스낵바 교체
+                    toast("'구역'을 먼저 선택해주세요")
+                }
+                viewModel.updateSelectedSectionId(viewModel.selectedSectionId.value)
+                if (viewModel.selectedSectionId.value == 10) {
+                    clColumnNumber.visibility = INVISIBLE
+                    clOnlyNumber.visibility = VISIBLE
+                    clOnlyColumnBtn.visibility = GONE
+                    clOnlyColumn.visibility = GONE
+                    val scale = context?.resources?.displayMetrics?.density
+                    val paddingInPx = (31 * scale!! + 0.5f).toInt()
+                    tvNoneColumnWarning.setPaddingRelative(paddingInPx, tvNoneColumnWarning.paddingTop, tvNoneColumnWarning.paddingEnd, tvNoneColumnWarning.paddingBottom)
+                } else {
+                    clColumnNumber.visibility = VISIBLE
+                    clOnlyNumber.visibility = INVISIBLE
+                    clOnlyColumn.visibility = INVISIBLE
+                    clOnlyColumnBtn.visibility = VISIBLE
+                    tvNoneColumnWarning.setPaddingRelative(tvNoneColumnWarning.paddingStart, tvNoneColumnWarning.paddingTop, tvNoneColumnWarning.paddingEnd, tvNoneColumnWarning.paddingBottom)
+                }
+                svSelectSeat.visibility = INVISIBLE
+                svSeatNumber.visibility = VISIBLE
+                tvSelectSeatLine.visibility = INVISIBLE
+                tvSelectNumberLine.visibility = VISIBLE
+                tvCompleteBtn.visibility = VISIBLE
+                tvNextBtn.visibility = GONE
+                clSeatBlock.visibility = VISIBLE
+                tvSelectZone.setTextColor(binding.root.context.colorOf(com.depromeet.designsystem.R.color.color_foreground_caption))
+                tvSelectNumber.setTextColor(binding.root.context.colorOf(com.depromeet.designsystem.R.color.color_foreground_heading))
+            }
+            binding.llTabSelectSection.setOnSingleClickListener {
+                viewModel.selectedSeatZone.asLiveData().observe(viewLifecycleOwner) { zone ->
+                    if (zone.isNotEmpty()) {
+                        svSelectSeat.visibility = VISIBLE
+                        clSeatBlock.visibility = INVISIBLE
+                        svSeatNumber.visibility = INVISIBLE
+                        tvSelectSeatLine.visibility = VISIBLE
+                        tvSelectNumberLine.visibility = INVISIBLE
+                        tvCompleteBtn.visibility = INVISIBLE
+                        tvNextBtn.visibility = VISIBLE
+                        tvSelectZone.setTextColor(binding.root.context.colorOf(com.depromeet.designsystem.R.color.color_foreground_heading))
+                        tvSelectNumber.setTextColor(binding.root.context.colorOf(com.depromeet.designsystem.R.color.color_foreground_caption))
+                    }
+                }
+                if (viewModel.selectedBlock.value.isNotEmpty() && (viewModel.selectedColumn.value.isNotEmpty() || viewModel.selectedNumber.value.isNotEmpty())) {
+                    svSelectSeat.visibility = VISIBLE
+                    clSeatBlock.visibility = INVISIBLE
+                    svSeatNumber.visibility = INVISIBLE
+                    tvSelectSeatLine.visibility = VISIBLE
+                    tvSelectNumberLine.visibility = INVISIBLE
+                    tvSelectZone.setTextColor(binding.root.context.colorOf(com.depromeet.designsystem.R.color.color_foreground_heading))
+                    tvSelectNumber.setTextColor(binding.root.context.colorOf(com.depromeet.designsystem.R.color.color_foreground_caption))
+                    tvCompleteBtn.visibility = VISIBLE
+                    tvNextBtn.visibility = INVISIBLE
+                } else {
+                    svSelectSeat.visibility = VISIBLE
+                    clSeatBlock.visibility = INVISIBLE
+                    svSeatNumber.visibility = INVISIBLE
+                    tvSelectSeatLine.visibility = VISIBLE
+                    tvSelectNumberLine.visibility = INVISIBLE
+                    tvSelectZone.setTextColor(binding.root.context.colorOf(com.depromeet.designsystem.R.color.color_foreground_heading))
+                    tvSelectNumber.setTextColor(binding.root.context.colorOf(com.depromeet.designsystem.R.color.color_foreground_caption))
+                    tvCompleteBtn.visibility = INVISIBLE
+                    tvNextBtn.visibility = VISIBLE
+                }
             }
         }
     }
@@ -217,6 +274,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
                     putBoolean("isColumnCheckEnabled", isColumnCheckEnabled)
                 }
                 parentFragmentManager.setFragmentResult("selectSeatResult", result)
+                viewModel.updateItemSelected(false)
                 dismiss()
             }
         }
@@ -320,7 +378,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
                 viewModel.userSeatState.value = ValidSeat.INVALID_COLUMN
             } else if (matchingRowInfo != null) {
                 viewModel.userSeatState.value = ValidSeat.VALID
-            } else{
+            } else {
                 viewModel.userSeatState.value = ValidSeat.NONE
             }
         }

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
@@ -98,14 +98,14 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
 
     private fun onClickStadiumName() {
         binding.clSelectStadium.setOnSingleClickListener {
-            makeSpotImageAppbar("나중에 다른 구장도 추가될 예정이에요!")
+            makeSpotImageAppbar("나중에 다른 구장도 추가될 예정이에요!",39)
         }
     }
 
     private fun createPreventTouchListener(message: String): View.OnTouchListener {
         return View.OnTouchListener { v, event ->
             if (event.action == MotionEvent.ACTION_UP) {
-                makeSpotImageAppbar(message)
+                makeSpotImageAppbar(message,71)
                 v.performClick()
                 true
             } else {
@@ -117,7 +117,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
         with(binding) {
             llTabSelectSeat.setOnSingleClickListener {
                 if (!viewModel.sectionItemSelected.value) {
-                    makeSpotImageAppbar("‘구역'을 먼저 선택해주세요")
+                    makeSpotImageAppbar("‘구역'을 먼저 선택해주세요",71)
                     val preventTouchListener = createPreventTouchListener("‘구역'을 먼저 선택해주세요")
                     spinnerBlock.setOnTouchListener(preventTouchListener)
                     etColumn.setOnTouchListener(preventTouchListener)
@@ -131,7 +131,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
                 }
                 viewModel.updateSelectedSectionId(viewModel.selectedSectionId.value)
                 if (viewModel.selectedSectionId.value == 10) {
-                    makeSpotImageAppbar("휠체어석의 ‘열’은 수정할 수 없어요")
+                    makeSpotImageAppbar("휠체어석의 ‘열’은 수정할 수 없어요",50)
                     clColumnNumber.visibility = INVISIBLE
                     clOnlyNumber.visibility = VISIBLE
                     clOnlyColumnBtn.visibility = GONE
@@ -281,7 +281,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
                     val scale = context?.resources?.displayMetrics?.density
                     val paddingInPx = (31 * scale!! + 0.5f).toInt()
                     tvNoneColumnWarning.setPaddingRelative(paddingInPx, tvNoneColumnWarning.paddingTop, tvNoneColumnWarning.paddingEnd, tvNoneColumnWarning.paddingBottom)
-                    makeSpotImageAppbar("휠체어석의 ‘열’은 수정할 수 없어요")
+                    makeSpotImageAppbar("휠체어석의 ‘열’은 수정할 수 없어요",50)
                 } else {
                     clColumnNumber.visibility = VISIBLE
                     clOnlyNumber.visibility = INVISIBLE
@@ -623,7 +623,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
         }
     }
 
-    private fun makeSpotImageAppbar(message: String) {
+    private fun makeSpotImageAppbar(message: String, marginHorizontal: Int) {
         val parentView = requireDialog().window?.decorView?.findViewById<View>(android.R.id.content)
         parentView?.let {
             SpotImageSnackBar.make(
@@ -633,7 +633,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
                 icon = com.depromeet.designsystem.R.drawable.ic_alert_circle,
                 iconColor = com.depromeet.designsystem.R.color.color_error_secondary,
                 marginBottom = 96,
-                marginHorizontal = 71,
+                marginHorizontal = marginHorizontal,
             ).show()
         }
     }

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
@@ -98,14 +98,14 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
 
     private fun onClickStadiumName() {
         binding.clSelectStadium.setOnSingleClickListener {
-            makeSpotImageAppbar("나중에 다른 구장도 추가될 예정이에요!",39)
+            makeSpotImageAppbar("나중에 다른 구장도 추가될 예정이에요!")
         }
     }
 
     private fun createPreventTouchListener(message: String): View.OnTouchListener {
         return View.OnTouchListener { v, event ->
             if (event.action == MotionEvent.ACTION_UP) {
-                makeSpotImageAppbar(message,71)
+                makeSpotImageAppbar(message)
                 v.performClick()
                 true
             } else {
@@ -117,7 +117,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
         with(binding) {
             llTabSelectSeat.setOnSingleClickListener {
                 if (!viewModel.sectionItemSelected.value) {
-                    makeSpotImageAppbar("‘구역'을 먼저 선택해주세요",71)
+                    makeSpotImageAppbar("‘구역'을 먼저 선택해주세요")
                     val preventTouchListener = createPreventTouchListener("‘구역'을 먼저 선택해주세요")
                     spinnerBlock.setOnTouchListener(preventTouchListener)
                     etColumn.setOnTouchListener(preventTouchListener)
@@ -131,7 +131,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
                 }
                 viewModel.updateSelectedSectionId(viewModel.selectedSectionId.value)
                 if (viewModel.selectedSectionId.value == 10) {
-                    makeSpotImageAppbar("휠체어석의 ‘열’은 수정할 수 없어요",50)
+                    makeSpotImageAppbar("휠체어석의 ‘열’은 수정할 수 없어요")
                     clColumnNumber.visibility = INVISIBLE
                     clOnlyNumber.visibility = VISIBLE
                     clOnlyColumnBtn.visibility = GONE
@@ -281,7 +281,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
                     val scale = context?.resources?.displayMetrics?.density
                     val paddingInPx = (31 * scale!! + 0.5f).toInt()
                     tvNoneColumnWarning.setPaddingRelative(paddingInPx, tvNoneColumnWarning.paddingTop, tvNoneColumnWarning.paddingEnd, tvNoneColumnWarning.paddingBottom)
-                    makeSpotImageAppbar("휠체어석의 ‘열’은 수정할 수 없어요",50)
+                    makeSpotImageAppbar("휠체어석의 ‘열’은 수정할 수 없어요")
                 } else {
                     clColumnNumber.visibility = VISIBLE
                     clOnlyNumber.visibility = INVISIBLE
@@ -623,7 +623,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
         }
     }
 
-    private fun makeSpotImageAppbar(message: String, marginHorizontal: Int) {
+    private fun makeSpotImageAppbar(message: String) {
         val parentView = binding.root.rootView
         parentView?.let {
             SpotImageSnackBar.make(
@@ -633,7 +633,6 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
                 icon = com.depromeet.designsystem.R.drawable.ic_alert_circle,
                 iconColor = com.depromeet.designsystem.R.color.color_error_secondary,
                 marginBottom = 96,
-                marginHorizontal = marginHorizontal,
             ).show()
         }
     }

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
@@ -2,6 +2,7 @@ package com.dpm.presentation.seatreview.dialog
 
 import android.os.Bundle
 import android.text.Editable
+import android.view.MotionEvent
 import android.view.View
 import android.view.View.FOCUS_DOWN
 import android.view.View.GONE
@@ -100,11 +101,33 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
             makeSpotImageAppbar("나중에 다른 구장도 추가될 예정이에요!")
         }
     }
+
+    private fun createPreventTouchListener(message: String): View.OnTouchListener {
+        return View.OnTouchListener { v, event ->
+            if (event.action == MotionEvent.ACTION_UP) {
+                makeSpotImageAppbar(message)
+                v.performClick()
+                true
+            } else {
+                false
+            }
+        }
+    }
     private fun onClickTabVisibility() {
         with(binding) {
-            binding.llTabSelectSeat.setOnSingleClickListener {
+            llTabSelectSeat.setOnSingleClickListener {
                 if (!viewModel.sectionItemSelected.value) {
                     makeSpotImageAppbar("‘구역'을 먼저 선택해주세요")
+                    val preventTouchListener = createPreventTouchListener("‘구역'을 먼저 선택해주세요")
+                    spinnerBlock.setOnTouchListener(preventTouchListener)
+                    etColumn.setOnTouchListener(preventTouchListener)
+                    etNumber.setOnTouchListener(preventTouchListener)
+                    etOnlyColumn.setOnTouchListener(preventTouchListener)
+                } else {
+                    spinnerBlock.setOnTouchListener(null)
+                    etColumn.setOnTouchListener(null)
+                    etNumber.setOnTouchListener(null)
+                    etOnlyColumn.setOnTouchListener(null)
                 }
                 viewModel.updateSelectedSectionId(viewModel.selectedSectionId.value)
                 if (viewModel.selectedSectionId.value == 10) {
@@ -124,6 +147,12 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
                     tvNoneColumnWarning.setPaddingRelative(tvNoneColumnWarning.paddingStart, tvNoneColumnWarning.paddingTop, tvNoneColumnWarning.paddingEnd, tvNoneColumnWarning.paddingBottom)
                 }
                 svSelectSeat.visibility = INVISIBLE
+                if (isColumnCheckEnabled) {
+                    svSeatNumber.visibility = VISIBLE
+                    btnCheckColumn.setBackgroundResource(com.depromeet.designsystem.R.drawable.rect_spot_green_fill_4)
+                    clColumnNumber.visibility = INVISIBLE
+                    clOnlyColumn.visibility = VISIBLE
+                }
                 svSeatNumber.visibility = VISIBLE
                 tvSelectSeatLine.visibility = INVISIBLE
                 tvSelectNumberLine.visibility = VISIBLE
@@ -240,6 +269,10 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
         with(binding) {
             tvNextBtn.setOnSingleClickListener {
                 viewModel.updateSelectedSectionId(viewModel.selectedSectionId.value)
+                spinnerBlock.setOnTouchListener(null)
+                etColumn.setOnTouchListener(null)
+                etNumber.setOnTouchListener(null)
+                etOnlyColumn.setOnTouchListener(null)
                 if (viewModel.selectedSectionId.value == 10) {
                     clColumnNumber.visibility = INVISIBLE
                     clOnlyNumber.visibility = VISIBLE

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
@@ -41,7 +41,6 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
     private val viewModel: ReviewViewModel by activityViewModels()
     private lateinit var adapter: SelectSeatAdapter
     private var isColumnCheckEnabled = false
-    private val parentView = requireDialog().window?.decorView?.findViewById<View>(android.R.id.content)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -98,39 +97,18 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
 
     private fun onClickStadiumName() {
         binding.clSelectStadium.setOnSingleClickListener {
-            parentView?.let {
-                SpotImageSnackBar.make(
-                    it,
-                    message = "나중에 다른 구장도 추가될 예정이에요!",
-                    messageColor = com.depromeet.designsystem.R.color.color_foreground_white,
-                    icon = com.depromeet.designsystem.R.drawable.ic_alert_circle,
-                    iconColor = com.depromeet.designsystem.R.color.color_error_secondary,
-                    marginBottom = 96,
-                    marginHorizontal = 39,
-
-                ).show()
-            }
+            makeSpotImageAppbar("나중에 다른 구장도 추가될 예정이에요!")
         }
     }
     private fun onClickTabVisibility() {
         with(binding) {
             binding.llTabSelectSeat.setOnSingleClickListener {
                 if (!viewModel.sectionItemSelected.value) {
-                    parentView?.let {
-                        SpotImageSnackBar.make(
-                            it,
-                            message = "나중에 다른 구장도 추가될 예정이에요!",
-                            messageColor = com.depromeet.designsystem.R.color.color_foreground_white,
-                            icon = com.depromeet.designsystem.R.drawable.ic_alert_circle,
-                            iconColor = com.depromeet.designsystem.R.color.color_error_secondary,
-                            marginBottom = 96,
-                            marginHorizontal = 71,
-                        ).show()
-                    }
-                    toast("'구역'을 먼저 선택해주세요")
+                    makeSpotImageAppbar("‘구역'을 먼저 선택해주세요")
                 }
                 viewModel.updateSelectedSectionId(viewModel.selectedSectionId.value)
                 if (viewModel.selectedSectionId.value == 10) {
+                    makeSpotImageAppbar("휠체어석의 ‘열’은 수정할 수 없어요")
                     clColumnNumber.visibility = INVISIBLE
                     clOnlyNumber.visibility = VISIBLE
                     clOnlyColumnBtn.visibility = GONE
@@ -270,6 +248,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
                     val scale = context?.resources?.displayMetrics?.density
                     val paddingInPx = (31 * scale!! + 0.5f).toInt()
                     tvNoneColumnWarning.setPaddingRelative(paddingInPx, tvNoneColumnWarning.paddingTop, tvNoneColumnWarning.paddingEnd, tvNoneColumnWarning.paddingBottom)
+                    makeSpotImageAppbar("휠체어석의 ‘열’은 수정할 수 없어요")
                 } else {
                     clColumnNumber.visibility = VISIBLE
                     clOnlyNumber.visibility = INVISIBLE
@@ -608,6 +587,21 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
 
                 else -> {}
             }
+        }
+    }
+
+    private fun makeSpotImageAppbar(message: String) {
+        val parentView = requireDialog().window?.decorView?.findViewById<View>(android.R.id.content)
+        parentView?.let {
+            SpotImageSnackBar.make(
+                it,
+                message = message,
+                messageColor = com.depromeet.designsystem.R.color.color_foreground_white,
+                icon = com.depromeet.designsystem.R.drawable.ic_alert_circle,
+                iconColor = com.depromeet.designsystem.R.color.color_error_secondary,
+                marginBottom = 96,
+                marginHorizontal = 71,
+            ).show()
         }
     }
     override fun onDestroyView() {

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
@@ -21,6 +21,7 @@ import com.depromeet.presentation.R
 import com.depromeet.presentation.databinding.FragmentSelectSeatBottomSheetBinding
 import com.dpm.core.base.BindingBottomSheetDialog
 import com.dpm.core.state.UiState
+import com.dpm.designsystem.SpotImageSnackBar
 import com.dpm.domain.entity.response.seatreview.ResponseSeatBlock
 import com.dpm.domain.entity.response.seatreview.ResponseSeatRange
 import com.dpm.domain.model.seatreview.ValidSeat
@@ -40,6 +41,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
     private val viewModel: ReviewViewModel by activityViewModels()
     private lateinit var adapter: SelectSeatAdapter
     private var isColumnCheckEnabled = false
+    private val parentView = requireDialog().window?.decorView?.findViewById<View>(android.R.id.content)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -60,7 +62,6 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
         initEvent()
         initObserve()
     }
-
     private fun initView() {
         adapter = SelectSeatAdapter { position, sectionId ->
             val selectedSeatInfo = adapter.currentList[position]
@@ -81,6 +82,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
         binding.ivHelpCircle.setOnSingleClickListener { onClickToggleSeatVisibility() }
         binding.ivWhatColumnChevron.setOnSingleClickListener { onClickToggleSeatVisibility() }
         binding.tvWhatColumn.setOnSingleClickListener { onClickToggleSeatVisibility() }
+        onClickStadiumName()
         onClickTabVisibility()
         onClickToggleSectionVisibility()
         onClickCheckOnlyColumn()
@@ -94,11 +96,37 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
         initObserveSeatRange()
     }
 
+    private fun onClickStadiumName() {
+        binding.clSelectStadium.setOnSingleClickListener {
+            parentView?.let {
+                SpotImageSnackBar.make(
+                    it,
+                    message = "나중에 다른 구장도 추가될 예정이에요!",
+                    messageColor = com.depromeet.designsystem.R.color.color_foreground_white,
+                    icon = com.depromeet.designsystem.R.drawable.ic_alert_circle,
+                    iconColor = com.depromeet.designsystem.R.color.color_error_secondary,
+                    marginBottom = 96,
+                    marginHorizontal = 39,
+
+                ).show()
+            }
+        }
+    }
     private fun onClickTabVisibility() {
         with(binding) {
             binding.llTabSelectSeat.setOnSingleClickListener {
                 if (!viewModel.sectionItemSelected.value) {
-                    // TODO : 스낵바 교체
+                    parentView?.let {
+                        SpotImageSnackBar.make(
+                            it,
+                            message = "나중에 다른 구장도 추가될 예정이에요!",
+                            messageColor = com.depromeet.designsystem.R.color.color_foreground_white,
+                            icon = com.depromeet.designsystem.R.drawable.ic_alert_circle,
+                            iconColor = com.depromeet.designsystem.R.color.color_error_secondary,
+                            marginBottom = 96,
+                            marginHorizontal = 71,
+                        ).show()
+                    }
                     toast("'구역'을 먼저 선택해주세요")
                 }
                 viewModel.updateSelectedSectionId(viewModel.selectedSectionId.value)
@@ -581,5 +609,9 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
                 else -> {}
             }
         }
+    }
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
@@ -637,8 +637,4 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
             ).show()
         }
     }
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
-    }
 }

--- a/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
+++ b/presentation/src/main/java/com/dpm/presentation/seatreview/dialog/SelectSeatDialog.kt
@@ -624,7 +624,7 @@ class SelectSeatDialog : BindingBottomSheetDialog<FragmentSelectSeatBottomSheetB
     }
 
     private fun makeSpotImageAppbar(message: String, marginHorizontal: Int) {
-        val parentView = requireDialog().window?.decorView?.findViewById<View>(android.R.id.content)
+        val parentView = binding.root.rootView
         parentView?.let {
             SpotImageSnackBar.make(
                 it,

--- a/presentation/src/main/res/layout/fragment_review_my_seat_bottom_sheet.xml
+++ b/presentation/src/main/res/layout/fragment_review_my_seat_bottom_sheet.xml
@@ -350,7 +350,7 @@
                     android:textAppearance="@style/TextAppearance.Spot.Body02"
                     android:textColor="@color/color_foreground_body_subtitle"
                     android:textColorHint="@color/color_foreground_disabled"
-                    android:visibility="visible"
+                    android:visibility="gone"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent" />

--- a/presentation/src/main/res/layout/fragment_review_my_seat_bottom_sheet.xml
+++ b/presentation/src/main/res/layout/fragment_review_my_seat_bottom_sheet.xml
@@ -281,7 +281,25 @@
                     android:background="@drawable/sel_review_color_seat_bad_review"
                     android:paddingHorizontal="12dp"
                     android:paddingVertical="13dp"
-                    android:text="📢시끄러운 스피커"
+                    android:text="📢 시끄러운 스피커"
+                    android:textAppearance="@style/TextAppearance.Spot.Label08"
+                    android:textColor="@color/color_foreground_body_subtitle" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/tv_bad_seven"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/sel_review_color_seat_bad_review"
+                    android:paddingHorizontal="12dp"
+                    android:paddingVertical="13dp"
+                    android:text="🪟 유리막이 있는 자리"
                     android:textAppearance="@style/TextAppearance.Spot.Label08"
                     android:textColor="@color/color_foreground_body_subtitle" />
             </LinearLayout>

--- a/presentation/src/main/res/layout/fragment_select_seat_bottom_sheet.xml
+++ b/presentation/src/main/res/layout/fragment_select_seat_bottom_sheet.xml
@@ -60,6 +60,7 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/llTabSelectSeat"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="24dp"


### PR DESCRIPTION
- closed #104 

## **💻주요 작업 내용**
- [x] 열만 입력, 번만 입력 (*휠체어석) -> DTO 수정 
- [x] 서버 변경 -> 익사이팅석, 프리미엄석 하드코딩
- [x] 좌석선택- [구역선택]-[좌석번호] 간 탭이동                                   
- [x] 리뷰 등록 관련 스낵바 추가
## **🎞리뷰 요청 사항**
- 이제 예외 케이스 및 열만 입력 등록 서버 배포돼서 잘됩니다. 확인부탁드려요 😎
- 제 뷰는 사소한 변경사항들이 많아, 큰 등록 플로우 변경되기 전에 먼저 구현하는게 맞다고 판단해서 이번에 pr 단위를 좀 작게 가져갑니다 ! 
- 2차 MVP 1 / 2 / 3 차 구현 중 두번째 pr입니다 ~! 아자자 🤪
